### PR TITLE
fix: configure CodeQL to scan Python only

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,7 @@ jobs:
     name: Analyze (Python)
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Add explicit CodeQL workflow targeting only Python
- Disable the default CodeQL setup which was scanning `actions` language and failing with: "CodeQL detected code written in GitHub Actions but could not process any of it"
- The repo is a Python project — only Python scanning is needed

## Changes
- Added `.github/workflows/codeql-analysis.yml` with Python-only CodeQL analysis
- Disabled the default CodeQL setup via API (was configured for `actions` + `python`)

## Test plan
- [ ] Verify the CodeQL workflow runs successfully on this PR
- [ ] Confirm no more `actions` language scan failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)