### PR TITLE
chore: refine CodeRabbit config to exclude non-code directories

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,12 +7,20 @@ reviews:
     drafts: false
     base_branches:
       - main
+  path_filters:
+    - "!_bmad/**"
+    - "!_bmad-output/**"
+    - "!.claude/**"
   path_instructions:
-    - path: "**/*.py"
+    - path: "**/*.ts"
       instructions: >
-        Focus on Python best practices, type hints, error handling,
-        and security considerations. Flag any potential issues with
-        subprocess calls or shell command injection.
+        Focus on TypeScript best practices, strict typing, error handling,
+        and security considerations. This is an Electron app using React
+        and the Claude Agent SDK.
+    - path: "**/*.tsx"
+      instructions: >
+        Focus on React component best practices, proper typing, accessibility,
+        and performance. Use React Testing Library patterns for testability.
   request_changes_workflow: false
   high_level_summary: true
   poem: false


### PR DESCRIPTION
## Summary
- Add `path_filters` to exclude `_bmad/**`, `_bmad-output/**`, and `.claude/**` from reviews
- Fix `path_instructions` from Python to TypeScript/React (the actual project stack)
- These are BMAD method templates, generated planning artifacts, and Claude Code config — not project code
- Reduces review noise and focuses CodeRabbit on actual source code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review configuration to refine which files trigger reviews and adjusted language-specific guidance for the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->