### PR TITLE
chore: refine SonarCloud exclusions for non-code directories

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,5 +2,4 @@ sonar.projectKey=petry-projects_TalkTerm
 sonar.organization=petry-projects
 sonar.projectName=TalkTerm
 sonar.sources=.
-sonar.python.version=3.11
-sonar.exclusions=_bmad-output/**,_bmad/**,.claude/**,docs/**
+sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**,docs/**


### PR DESCRIPTION
## Summary
- Remove incorrect `sonar.python.version=3.11` (this is a TypeScript project)
- Ensures `_bmad/**`, `_bmad-output/**`, and `.claude/**` are all excluded
- Keeps existing `docs/**` exclusion
- Reduces scan noise and focuses analysis on actual source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)