### PR TITLE
chore: enable Claude issue trigger per org CI standard

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,6 +8,8 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  issues:
+    types: [labeled]
 
 permissions: {}
 
@@ -21,17 +23,21 @@ jobs:
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' &&
+        github.event.label.name == 'claude')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      contents: read
+      # write required for issue-triggered branch creation
+      contents: write
       id-token: write
       pull-requests: write
       issues: write
     steps:
       - name: Run Claude Code
         if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
-        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47 # v1
+        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          label_trigger: "claude"


### PR DESCRIPTION
## Summary

- Add `issues: [labeled]` event trigger to `claude.yml` workflow
- Add `label_trigger: "claude"` input to claude-code-action
- Upgrade `contents: read` → `contents: write` (required for issue-triggered branch creation)
- Pin to `claude-code-action@v1.0.89`

Implements the standard defined in [petry-projects/.github#24](https://github.com/petry-projects/.github/pull/24).

## What this enables

When the `claude` label is applied to an issue, Claude Code will autonomously:
1. Read the issue
2. Create a branch
3. Implement the fix
4. Open a PR

## Test plan

- [ ] CI passes (non-claude checks)
- [ ] `claude` label exists on repo
- [ ] Applying `claude` label to an issue triggers the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)