### PR TITLE
chore: add label definitions and setup script (closes #45)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,53 @@
+# Repository label definitions
+#
+# This file documents the required labels for this repository per the
+# petry-projects organization standard:
+# https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#labels--standard-set
+#
+# To apply these labels, run:
+#   bash scripts/setup-labels.sh
+#
+# Or with github-labeler action:
+#   - uses: EndBug/label-sync@v2
+#     with:
+#       config-file: .github/labels.yml
+
+- name: bug
+  color: "d73a4a"
+  description: "Something isn't working"
+
+- name: documentation
+  color: "0075ca"
+  description: "Improvements or additions to documentation"
+
+- name: duplicate
+  color: "cfd3d7"
+  description: "This issue or pull request already exists"
+
+- name: enhancement
+  color: "a2eeef"
+  description: "New feature or request"
+
+- name: good first issue
+  color: "7057ff"
+  description: "Good for newcomers"
+
+- name: help wanted
+  color: "008672"
+  description: "Extra attention is needed"
+
+- name: invalid
+  color: "e4e669"
+  description: "This doesn't seem right"
+
+- name: question
+  color: "d876e3"
+  description: "Further information is requested"
+
+- name: security
+  color: "e11d48"
+  description: "Security vulnerability or concern"
+
+- name: wontfix
+  color: "ffffff"
+  description: "This will not be worked on"

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# setup-labels.sh — Create required repository labels from .github/labels.yml
+#
+# Usage:
+#   bash scripts/setup-labels.sh [--repo OWNER/REPO]
+#
+# Prerequisites:
+#   - GitHub CLI (gh) installed and authenticated
+#   - Repository admin or write access
+#
+# This script is idempotent: existing labels are updated, new ones are created.
+
+set -euo pipefail
+
+REPO="${GH_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+
+if [ -n "$1" ] && [ "$1" = "--repo" ]; then
+  REPO="$2"
+fi
+
+echo "Setting up labels for: $REPO"
+echo ""
+
+# Define labels inline (matches .github/labels.yml)
+declare -a LABEL_NAMES=(
+  "bug"
+  "documentation"
+  "duplicate"
+  "enhancement"
+  "good first issue"
+  "help wanted"
+  "invalid"
+  "question"
+  "security"
+  "wontfix"
+)
+
+declare -a LABEL_COLORS=(
+  "d73a4a"
+  "0075ca"
+  "cfd3d7"
+  "a2eeef"
+  "7057ff"
+  "008672"
+  "e4e669"
+  "d876e3"
+  "e11d48"
+  "ffffff"
+)
+
+declare -a LABEL_DESCS=(
+  "Something isn't working"
+  "Improvements or additions to documentation"
+  "This issue or pull request already exists"
+  "New feature or request"
+  "Good for newcomers"
+  "Extra attention is needed"
+  "This doesn't seem right"
+  "Further information is requested"
+  "Security vulnerability or concern"
+  "This will not be worked on"
+)
+
+for i in "${!LABEL_NAMES[@]}"; do
+  name="${LABEL_NAMES[$i]}"
+  color="${LABEL_COLORS[$i]}"
+  desc="${LABEL_DESCS[$i]}"
+
+  if gh label list --repo "$REPO" --json name -q '.[].name' | grep -qx "$name"; then
+    echo "  Updating : $name"
+    gh label edit "$name" --repo "$REPO" --color "$color" --description "$desc"
+  else
+    echo "  Creating : $name"
+    gh label create "$name" --repo "$REPO" --color "$color" --description "$desc"
+  fi
+done
+
+echo ""
+echo "Done. All required labels are in place."


### PR DESCRIPTION
## Summary

- Adds `.github/labels.yml` documenting all required repository labels per the [petry-projects org standard](https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#labels--standard-set)
- Adds `scripts/setup-labels.sh` — an idempotent script to create/update all required labels via the GitHub CLI
- The `security` label (the compliance finding) is included in both files

## Applying the fix immediately

After merging, run this once from a terminal with `gh` authenticated:

```bash
bash scripts/setup-labels.sh
```

Or create the `security` label directly:

```bash
gh label create "security" --repo petry-projects/TalkTerm --color "e11d48" --description "Security vulnerability or concern"
```

## Why a script instead of direct creation

The Claude Code action sandbox does not include `gh label create` in its allowed tools, so the label cannot be created programmatically in this context. The setup script provides a repeatable, documented way to provision all required labels.

Closes #45

---
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub issue and pull request label configuration file for repository standardization.
  * Added automated label setup script to bootstrap and sync repository labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->