### PR TITLE
fix: rename codeql workflow and update language to javascript-typescript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   analyze:
-    name: Analyze (Python)
+    name: Analyze (javascript-typescript)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,9 +26,9 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
-          languages: python
+          languages: javascript-typescript
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
-          category: '/language:python'
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
## Summary

- Renames `.github/workflows/codeql-analysis.yml` → `.github/workflows/codeql.yml` to satisfy the compliance audit requirement for an exact filename match
- Updates the scanned language from `python` to `javascript-typescript` to match the TalkTerm stack (Electron + TypeScript + React)

## Changes

| | Before | After |
|---|---|---|
| Filename | `codeql-analysis.yml` | `codeql.yml` |
| Job name | `Analyze (Python)` | `Analyze (javascript-typescript)` |
| Language | `python` | `javascript-typescript` |
| Category | `/language:python` | `/language:javascript-typescript` |

Closes #41

Generated with [Claude Code](https://claude.ai/code)