### PR TITLE
fix: pin dtolnay/rust-toolchain to SHA for action-pinning compliance

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@21dc36fb71dd22e3317045c0c31a3f4249868b17 # stable
 
       - name: Install cargo-audit
         run: cargo install cargo-audit@0.21.1 --locked


### PR DESCRIPTION
## Summary

- Pins `dtolnay/rust-toolchain` from `@stable` to commit SHA `21dc36fb71dd22e3317045c0c31a3f4249868b17` in `.github/workflows/dependency-audit.yml`
- Matches the format already used for all other actions in the file (e.g. `actions/checkout@11bd71901... # v4`)
- The `cargo audit` job only runs when a `Cargo.toml` is detected — this repo has none — so this change has no runtime impact

Closes #42

Generated with [Claude Code](https://claude.ai/code)