### PR TITLE
chore: add labels.yml and create missing security label (closes #45)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,31 @@
+# Standard label set for petry-projects repositories.
+# Matches the required labels defined in:
+# https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#labels--standard-set
+
+- name: security
+  color: "d93f0b"
+  description: Security-related PRs and issues
+
+- name: dependencies
+  color: "0075ca"
+  description: Dependency update PRs
+
+- name: scorecard
+  color: "d93f0b"
+  description: OpenSSF Scorecard findings (auto-created)
+
+- name: bug
+  color: "d73a4a"
+  description: Bug reports
+
+- name: enhancement
+  color: "a2eeef"
+  description: Feature requests
+
+- name: documentation
+  color: "0075ca"
+  description: Documentation changes
+
+- name: in-progress
+  color: "fbca04"
+  description: An agent is actively working this issue


### PR DESCRIPTION
## Summary

- Creates the missing `security` label directly on the repository (color `#d93f0b`, description: "Security-related PRs and issues") — this resolves the compliance finding immediately.
- Adds `.github/labels.yml` documenting the full standard label set per [org standards](https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#labels--standard-set), so future audits and re-provisioning are straightforward.

Closes #45

## Labels created

| Label | Color | Description |
|-------|-------|-------------|
| `security` | `#d93f0b` | Security-related PRs and issues ✅ (was missing) |
| `dependencies` | `#0075ca` | Dependency update PRs |
| `scorecard` | `#d93f0b` | OpenSSF Scorecard findings |
| `bug` | `#d73a4a` | Bug reports |
| `enhancement` | `#a2eeef` | Feature requests |
| `documentation` | `#0075ca` | Documentation changes |
| `in-progress` | `#fbca04` | An agent is actively working this issue |

Generated with [Claude Code](https://claude.ai/code)