### PR TITLE
fix: sync dependency-audit.yml with org template (closes #42)

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,4 +1,5 @@
 # Dependency vulnerability audit
+# Copy to .github/workflows/dependency-audit.yml
 #
 # Auto-detects ecosystems present in the repository and runs the appropriate
 # audit tool. Fails the build if any dependency has a known security advisory.
@@ -6,7 +7,7 @@
 # Add "dependency-audit" as a required status check in branch protection.
 #
 # Pinned tool versions (update deliberately):
-#   govulncheck v1.1.4 | cargo-audit 0.21.1 | pip-audit 2.9.0
+#   govulncheck v1.1.4 | cargo-audit 0.22.1 | pip-audit 2.9.0
 name: Dependency audit
 
 on:
@@ -29,7 +30,7 @@ jobs:
       cargo: ${{ steps.check.outputs.cargo }}
       pip: ${{ steps.check.outputs.pip }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect package ecosystems
         id: check
@@ -76,9 +77,9 @@ jobs:
     if: needs.detect.outputs.npm == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "lts/*"
 
@@ -101,14 +102,13 @@ jobs:
     if: needs.detect.outputs.pnpm == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "lts/*"
-          cache: "pnpm"
 
       - name: Audit pnpm dependencies
         run: |
@@ -129,9 +129,9 @@ jobs:
     if: needs.detect.outputs.gomod == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
         with:
           go-version: "stable"
 
@@ -156,12 +156,13 @@ jobs:
     if: needs.detect.outputs.cargo == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust stable toolchain
+        run: rustup toolchain install stable --profile minimal
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit@0.21.1 --locked
+        run: cargo install cargo-audit@0.22.1 --locked
 
       - name: Audit Cargo dependencies
         run: |
@@ -183,7 +184,7 @@ jobs:
     if: needs.detect.outputs.pip == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:


### PR DESCRIPTION
## Summary

Syncs `.github/workflows/dependency-audit.yml` with the canonical org template at `petry-projects/.github/standards/workflows/dependency-audit.yml`.

The key change is that the template eliminates `dtolnay/rust-toolchain@stable` entirely — the unpinned action flagged in #42 — by using `rustup toolchain install stable --profile minimal` directly in a `run:` step. This requires no third-party action and no SHA to maintain.

Additional changes from the template sync:
- `actions/checkout` updated to `v6.0.2` (SHA `de0fac2e...`)
- `actions/setup-node` updated to `v6.3.0` (SHA `53b83947...`)
- `pnpm/action-setup` SHA updated to `fc06bc12...`
- `actions/setup-go` SHA updated to `4a360112...`
- `cargo-audit` bumped from `0.21.1` to `0.22.1`

Closes #42

Generated with [Claude Code](https://claude.ai/code)