### PR TITLE
fix: rename codeql workflow and add javascript-typescript + actions matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,23 +2,27 @@ name: CodeQL
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    branches:
-      - main
+    branches: [main]
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 17 * * 5' # Weekly scan (Friday 12:00 PM EST / 17:00 UTC)
 
 permissions: {}
 
 jobs:
   analyze:
-    name: Analyze (Python)
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
       security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - actions
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -26,9 +30,9 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
-          languages: python
+          languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
-          category: '/language:python'
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

- Renames `.github/workflows/codeql-analysis.yml` → `codeql.yml` (exact filename required by compliance audit)
- Replaces Python language with `javascript-typescript` (matches TalkTerm stack)
- Adds `actions` language scan (required per ci-standards.md: repos with `.github/workflows/*.yml` MUST scan the `actions` ecosystem)
- Adopts matrix strategy for multi-language scanning per org standard
- Updates schedule cron to Friday 17:00 UTC per org standard (`0 17 * * 5`)

All SHA pins verified via GitHub API.

Closes #41

Generated with [Claude Code](https://claude.ai/code)