### PR TITLE
ci: add ci.yml workflow for TypeScript + Electron stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+# Continuous Integration
+#
+# Runs quality gates on every push to main and every pull request targeting main.
+# All gates must pass before merging.
+#
+# Gates (per AGENTS.md §7):
+#   typecheck  → tsc --noEmit             (zero errors)
+#   lint       → eslint --max-warnings 0  (zero warnings)
+#   format     → prettier --check         (all files formatted)
+#   test       → vitest run               (all tests pass)
+#   coverage   → vitest run --coverage    (≥90% branch/fn/line/stmt)
+#   mutation   → stryker run              (≥80% score)   [continue-on-error]
+#   e2e        → playwright test          (macOS + Windows) [continue-on-error]
+#
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+# Tech stack pattern: TypeScript + Electron (npm)
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ── Build, lint, type check, test & coverage ──────────────────────────────
+  build-and-test:
+    name: Build and Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format -- --check
+
+      - name: Run tests with coverage
+        run: npm test -- --coverage
+
+  # ── Mutation testing ───────────────────────────────────────────────────────
+  mutation:
+    name: Mutation Testing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run mutation tests
+        run: npm run test:mutate
+
+  # ── End-to-end tests ───────────────────────────────────────────────────────
+  e2e:
+    name: E2E (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run E2E tests
+        run: npm run test:e2e


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` to satisfy the compliance requirement (issue #40)
- Follows the **Tier 2 per-repo pattern** for TypeScript + Electron (npm) from [ci-standards.md](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md)
- All action references are SHA-pinned per the Action Pinning Policy

## Quality gates

| Gate | Command | Threshold |
|------|---------|-----------|
| Type check | `tsc --noEmit` | Zero errors |
| Lint | `eslint --max-warnings 0` | Zero warnings |
| Format | `prettier --check` | All files formatted |
| Tests + Coverage | `vitest run --coverage` | ≥90% (matrix: ubuntu/macOS/Windows) |
| Mutation | `stryker run` | ≥80% score (`continue-on-error: true`) |
| E2E | `playwright test` | macOS + Windows (`continue-on-error: true`) |

## Notes

- `build-and-test` runs on all three OS targets (ubuntu, macOS, Windows) since Electron has native dependencies
- `mutation` and `e2e` use `continue-on-error: true` per standards (expensive; fail-fast would block PRs while source code is still being built out)
- `concurrency` cancels in-progress runs on the same ref to save CI minutes

Closes #40

Generated with [Claude Code](https://claude.ai/code)