### PR TITLE
fix(ci): pin claude-code-reusable.yml to SHA for action pinning compliance

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@208ec2d69b75227d375edf8745d84fbac05a76b2 # v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/claude-code-reusable.yml` from `@v1` to its exact commit SHA (`208ec2d69b75227d375edf8745d84fbac05a76b2`) with `# v1` comment for readability
- Resolves the `unpinned-actions-claude.yml` compliance finding from the weekly audit

## Standard

[ci-standards.md#action-pinning-policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)

Closes #86

Generated with [Claude Code](https://claude.ai/code)