### PR TITLE
fix(ci): pin dependabot-rebase reusable workflow to SHA

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -39,5 +39,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml` from `@v1` to commit SHA `ae9709f4466dec60a5733c9e7487f69dcd004e05` (v1)
- Resolves the `action-pinning` compliance finding raised by the weekly audit

## Motivation

The [Action Pinning Policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy) requires all `uses:` references to be pinned to a full commit SHA. Using a mutable tag like `@v1` allows the referenced workflow to change without notice, which is a supply-chain risk.

The SHA was resolved via:
```
gh api repos/petry-projects/.github/git/refs/tags/v1 --jq '.object.sha'
# → 208ec2d... (tag object)
gh api repos/petry-projects/.github/git/tags/208ec2d... --jq '.object.sha'
# → ae9709f4466dec60a5733c9e7487f69dcd004e05 (commit)
```

Closes #88

Generated with [Claude Code](https://claude.ai/code)