### PR TITLE
fix(ci): pin claude-code-reusable.yml to SHA for action-pinning compliance

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,12 +31,14 @@ on:
     types: [created]
   issues:
     types: [labeled]
+  check_run:
+    types: [completed]
 
 permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/claude-code-reusable.yml` from `@v1` to its exact commit SHA (`ee22b427cbce9ecadcf2b436acb57c3adf0cb63d`) as required by the [action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)
- Adopts the current standards template verbatim (added previously missing `check_run: types: [completed]` trigger)

## Changes

```diff
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
```

SHA verified via: `gh api repos/petry-projects/.github/git/refs/tags/v1 --jq '.object.sha'`

Closes #86

Generated with [Claude Code](https://claude.ai/code)