### PR TITLE
ci: add ci.yml workflow for TypeScript + Electron stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,113 @@
+# Continuous Integration
+#
+# Tech stack: TypeScript + Electron (npm) — Tier 2 per-repo workflow
+# Standard:   https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#1-ci-pipeline-ciyml
+# Pattern:    TypeScript + Electron (npm) — see ci-standards.md "Workflow Patterns by Tech Stack"
+#
+# Quality gates (per AGENTS.md §7):
+#   typecheck   → tsc --noEmit             zero errors
+#   lint        → eslint --max-warnings 0  zero warnings
+#   format      → prettier --check         all files formatted
+#   test        → vitest run               all tests pass
+#   coverage    → vitest --coverage        ≥90% branch/fn/line/stmt
+#   mutation    → stryker run              ≥80% score (continue-on-error)
+#   e2e         → playwright test          macOS + Windows (continue-on-error)
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ── Build & test (matrix: ubuntu · macOS · Windows) ────────────────────────
+  build-and-test:
+    name: Build & Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Test
+        run: npm test
+
+      - name: Coverage
+        run: npm run test:coverage
+
+  # ── Mutation testing (ubuntu only, non-blocking) ───────────────────────────
+  mutation:
+    name: Mutation Testing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run mutation tests
+        run: npm run test:mutate
+        continue-on-error: true
+
+  # ── E2E tests (macOS + Windows, non-blocking) ─────────────────────────────
+  e2e:
+    name: E2E (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+        continue-on-error: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` following the **Tier 2 per-repo pattern** for TypeScript + Electron (npm) as documented in the [org CI standards](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#1-ci-pipeline-ciyml)
- All action references are SHA-pinned per the [Action Pinning Policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)
- No `ci.yml` template exists in `standards/workflows/` (confirmed Tier 2 — per-repo pattern)

## Quality gates

| Gate | Command | Threshold | Blocking |
|------|---------|-----------|---------|
| Type check | `npm run typecheck` | Zero errors | Yes |
| Lint | `npm run lint` | Zero warnings | Yes |
| Format check | `npm run format:check` | All files formatted | Yes |
| Test | `npm test` | All pass | Yes |
| Coverage | `npm run test:coverage` | ≥90% | Yes |
| Mutation | `npm run test:mutate` | ≥80% | No (`continue-on-error`) |
| E2E | `npm run test:e2e` | macOS + Windows | No (`continue-on-error`) |

## Notes

- `build-and-test` runs in matrix across `ubuntu-latest`, `macos-latest`, `windows-latest`
- `mutation` runs on ubuntu only — `continue-on-error: true` (non-blocking per standards)
- `e2e` runs on `macos-latest` and `windows-latest` — `continue-on-error: true` (non-blocking per standards, since source code is not yet present)
- CI jobs that require source code (`package.json`, TypeScript files) will fail until those are added in subsequent stories — the workflow file itself satisfies the compliance requirement

Closes #40

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated continuous integration pipeline established to run testing and quality checks across multiple environments, ensuring code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->