### PR TITLE
fix(workflows): remove duplicate .github/ segment in agent-shield reusable ref

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/agent-shield.yml
 # Standard:        petry-projects/.github/standards/agent-standards.md
-# Reusable:        petry-projects/.github/.github/workflows/agent-shield-reusable.yml
+# Reusable:        petry-projects/.github/workflows/agent-shield-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. The AgentShield CLI scan and the
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/workflows/agent-shield-reusable.yml@v1


### PR DESCRIPTION
## Summary

- Fixes the `reusable-workflow-path-duplicate-github` compliance finding in `agent-shield.yml`
- Changes `petry-projects/.github/.github/workflows/` → `petry-projects/.github/workflows/` in both the `uses:` line and the header comment
- The `compliance-audit.sh` script explicitly requires this shorter form

## Changes

**`.github/workflows/agent-shield.yml`**
- `uses:` line: `petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1` → `petry-projects/.github/workflows/agent-shield-reusable.yml@v1`
- Header comment updated to match

Closes #129

Generated with [Claude Code](https://claude.ai/code)