### PR TITLE
fix(workflows): remove duplicate .github/ segment from reusable workflow paths

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/workflows/agent-shield-reusable.yml@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/workflows/claude-code-reusable.yml@v1
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/workflows/dependabot-automerge-reusable.yml@v1
     secrets: inherit

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -39,5 +39,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
+    uses: petry-projects/.github/workflows/dependabot-rebase-reusable.yml@v1
     secrets: inherit

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1
+    uses: petry-projects/.github/workflows/dependency-audit-reusable.yml@v1

--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -75,7 +75,7 @@ jobs:
       pull-requests: read
       discussions: write
       id-token: write
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@v1
+    uses: petry-projects/.github/workflows/feature-ideation-reusable.yml@v1
     with:
       # === CUSTOMISE THIS PER REPO — the only required edit ===
       # Replace this paragraph with a 3-5 sentence description of your project,


### PR DESCRIPTION
## Summary

- Removes the duplicate `.github/` path segment from all 6 reusable workflow caller stubs
- Correct format: `petry-projects/.github/workflows/*-reusable.yml@v1`
- Broken format (before): `petry-projects/.github/.github/workflows/*-reusable.yml@v1`

**Files fixed:** `agent-shield.yml`, `claude.yml`, `dependabot-automerge.yml`, `dependabot-rebase.yml`, `dependency-audit.yml`, `feature-ideation.yml`

The upstream org fixed this root cause in `petry-projects/.github` commit `956b3961` (2026-04-21), which corrected the path in their own `.github/workflows/` files and added the compliance audit check. This PR brings TalkTerm into compliance.

Closes #131

## Test plan
- [ ] Verify CI passes on this PR (each workflow stub should successfully call its reusable counterpart)
- [ ] Confirm the next weekly compliance audit no longer flags `reusable-workflow-path-duplicate-github` for this repo

Generated with [Claude Code](https://claude.ai/code)