### PR TITLE
Revert: Restore required double .github/ in reusable workflow paths

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/agent-shield.yml
 # Standard:        petry-projects/.github/standards/agent-standards.md
-# Reusable:        petry-projects/.github/workflows/agent-shield-reusable.yml
+# Reusable:        petry-projects/.github/.github/workflows/agent-shield-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. The AgentShield CLI scan and the
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/claude.yml
 # Standard:        petry-projects/.github/standards/ci-standards.md#4-claude-code-claudeyml
-# Reusable:        petry-projects/.github/workflows/claude-code-reusable.yml
+# Reusable:        petry-projects/.github/.github/workflows/claude-code-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All Claude Code logic, the prompt,
@@ -36,7 +36,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-automerge.yml
 # Standard:        petry-projects/.github/standards/dependabot-policy.md
-# Reusable:        petry-projects/.github/workflows/dependabot-automerge-reusable.yml
+# Reusable:        petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All eligibility logic and the GitHub
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
     secrets: inherit

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-rebase.yml
 # Standard:        petry-projects/.github/standards/dependabot-policy.md
-# Reusable:        petry-projects/.github/workflows/dependabot-rebase-reusable.yml
+# Reusable:        petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All rebase/merge serialization logic
@@ -39,5 +39,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/workflows/dependabot-rebase-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
     secrets: inherit

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependency-audit.yml
 # Standard:        petry-projects/.github/standards/ci-standards.md#5-dependency-audit-dependency-auditym
-# Reusable:        petry-projects/.github/workflows/dependency-audit-reusable.yml
+# Reusable:        petry-projects/.github/.github/workflows/dependency-audit-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All ecosystem-detection and audit logic
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/workflows/dependency-audit-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1

--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/feature-ideation.yml
 # Standard:        petry-projects/.github/standards/ci-standards.md#8-feature-ideation-feature-ideationyml--bmad-method-repos
-# Reusable:        petry-projects/.github/workflows/feature-ideation-reusable.yml
+# Reusable:        petry-projects/.github/.github/workflows/feature-ideation-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. The 5-phase ideation pipeline, the
@@ -19,7 +19,7 @@
 # Feature Ideation workflow stub — for BMAD Method-enabled repos.
 #
 # This is a thin caller for the org-wide reusable workflow at
-# petry-projects/.github/workflows/feature-ideation-reusable.yml
+# petry-projects/.github/.github/workflows/feature-ideation-reusable.yml
 # All ideation logic, the multi-skill pipeline, the Opus 4.6 model
 # selection, and the github_token override live in the reusable workflow.
 #
@@ -75,7 +75,7 @@ jobs:
       pull-requests: read
       discussions: write
       id-token: write
-    uses: petry-projects/.github/workflows/feature-ideation-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@v1
     with:
       # === CUSTOMISE THIS PER REPO — the only required edit ===
       # Replace this paragraph with a 3-5 sentence description of your project,


### PR DESCRIPTION
This reverts the broken fix that removed the required double .github/ segment.

The correct format for reusable workflow references is:
```
owner/repository/.github/workflows/name.yml
```

Where 'repository' is the actual repository name (e.g., '.github'), not a path segment.