### PR TITLE
fix: pin auto-rebase.yml to canonical @v1 stub per org standard

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -38,5 +38,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@126c1441ee9cf040f2ce3ef0eda85d459b82f8e9 # v1
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Replace SHA-pinned reusable workflow reference with the canonical `@v1` tag as required by the org compliance standard
- The file now exactly matches the canonical stub at `petry-projects/.github/standards/workflows/auto-rebase.yml`

**Change:** `.github/workflows/auto-rebase.yml`
- Before: `uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@126c1441ee9cf040f2ce3ef0eda85d459b82f8e9 # v1`
- After: `uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1`

Closes #138

Generated with [Claude Code](https://claude.ai/code)