### PR TITLE
fix: pin pr-review-mention reusable workflow to SHA

### DIFF
--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -34,5 +34,5 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@0cb4bba11d7563bf197ad805f12fb8639e4879e4 # v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml` from the floating `@v1` tag to commit SHA `0cb4bba11d7563bf197ad805f12fb8639e4879e4` (a.k.a. `v1`) to satisfy the [org action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy).

## Changes

`pr-review-mention.yml` line 37:
```diff
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@0cb4bba11d7563bf197ad805f12fb8639e4879e4 # v1
```

The `# v1` comment is retained so human readers can easily identify which release version the SHA corresponds to.

## Test plan

- [ ] Verify the SHA lookup: `gh api repos/petry-projects/.github/git/refs/tags/v1 --jq '.object.sha'` → `0cb4bba11d7563bf197ad805f12fb8639e4879e4`
- [ ] Confirm no other workflow files in this repo have unpinned actions
- [ ] CI compliance audit passes after merge

Closes #169

Generated with [Claude Code](https://claude.ai/code)