### PR TITLE
feat: add copilot-setup-steps.yml for Copilot cloud agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -50,7 +50,8 @@ permissions: {}
 
 jobs:
   copilot-setup-steps:
-    if: github.event.repository.fork == false
+    # Skip on fork-origin pull requests — forks cannot access org secrets required for private packages.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
 
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -96,7 +97,10 @@ jobs:
           else
             echo "ℹ️  .github/copilot-instructions.md — not present (optional but recommended)"
           fi
-          INSTR_COUNT=$(find .github/instructions -name "*.instructions.md" 2>/dev/null | wc -l)
+          INSTR_COUNT=0
+          if [ -d ".github/instructions" ]; then
+            INSTR_COUNT=$(find .github/instructions -name "*.instructions.md" | wc -l)
+          fi
           echo "ℹ️  .github/instructions/: ${INSTR_COUNT} file(s)"
           echo ""
           echo "✅ Setup complete — Copilot cloud agent is ready to work"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@
 #   • fetch-depth on checkout is always overridden by the agent — do not rely on it here
 #   • This file MUST be present on the default branch to take effect
 #
-# STACK: Node.js / npm (TypeScript + Electron desktop app)
+# STACK: documentation / scripts only — no build dependencies to install
 # ─────────────────────────────────────────────────────────────────────────────
 
 name: "Copilot Setup Steps"
@@ -54,7 +54,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
 
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
 
     permissions:
       contents: read
@@ -62,15 +62,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: "24"
-          cache: "npm"
-
-      - name: Install Node.js dependencies
-        run: npm ci
 
       - name: Verify environment
         run: |
@@ -82,8 +73,6 @@ jobs:
           echo "--- Installed tool versions ---"
           git   --version
           gh    --version 2>/dev/null | head -1 || echo "gh: not installed"
-          node  --version
-          npm   --version
           echo ""
           echo "--- Agent instruction files ---"
           if [ -f "AGENTS.md" ]; then

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,102 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/copilot-setup-steps.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md#11-copilot-cloud-agent-setup
+#
+# ADOPTING THIS WORKFLOW:
+#   1. Copy this file to .github/workflows/copilot-setup-steps.yml in your repo.
+#   2. Keep every REQUIRED section — do NOT remove the checkout or verify steps.
+#   3. Uncomment and adapt the stack blocks that match your repo's tech stack.
+#   4. Delete (not just comment out) stacks that do not apply after initial setup.
+#   5. Merge to the default branch — the workflow only triggers from the default branch.
+#   6. Run manually from Actions → "Copilot Setup Steps" → "Run workflow" to verify.
+#
+# WHAT THIS FILE DOES:
+#   Bootstraps Copilot cloud agent's ephemeral environment BEFORE the agent starts
+#   working on your repo. Pre-installing dependencies deterministically:
+#     • Speeds up every agent session (no trial-and-error dependency discovery)
+#     • Makes private/internal packages available (impossible for the agent alone)
+#     • Ensures exact tool versions that match your CI pipeline
+#   Without this file the agent installs dependencies itself — slower, non-deterministic,
+#   and unreliable for repos with private packages or complex build graphs.
+#
+# SEE ALSO:
+#   AGENTS.md                         — authoritative development standards for this repo
+#   .github/copilot-instructions.md   — always-on Copilot instructions (summary of AGENTS.md)
+#   .github/instructions/             — path-scoped instruction files per language
+#
+# CONSTRAINTS (enforced by GitHub, documented at docs.github.com):
+#   • Job MUST be named `copilot-setup-steps` to be recognized by Copilot cloud agent
+#   • timeout-minutes maximum: 59 (hard limit)
+#   • Customizable fields: steps, permissions, runs-on, services, snapshot, timeout-minutes
+#   • All other job-level settings are silently ignored by GitHub
+#   • fetch-depth on checkout is always overridden by the agent — do not rely on it here
+#   • This file MUST be present on the default branch to take effect
+#
+# STACK: Node.js / npm (TypeScript + Electron desktop app)
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions: {}
+
+jobs:
+  copilot-setup-steps:
+    if: github.event.repository.fork == false
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Verify environment
+        run: |
+          echo "=== petry-projects Copilot cloud agent environment ==="
+          echo "Repository : ${{ github.repository }}"
+          echo "Ref        : ${{ github.ref }}"
+          echo "Runner     : ${{ runner.os }} / ${{ runner.arch }}"
+          echo ""
+          echo "--- Installed tool versions ---"
+          git   --version
+          gh    --version 2>/dev/null | head -1 || echo "gh: not installed"
+          node  --version
+          npm   --version
+          echo ""
+          echo "--- Agent instruction files ---"
+          if [ -f "AGENTS.md" ]; then
+            echo "✅ AGENTS.md ($(wc -l < AGENTS.md) lines)"
+          else
+            echo "❌ AGENTS.md — MISSING. Add this file per agent-standards.md."
+            exit 1
+          fi
+          if [ -f ".github/copilot-instructions.md" ]; then
+            echo "✅ .github/copilot-instructions.md"
+          else
+            echo "ℹ️  .github/copilot-instructions.md — not present (optional but recommended)"
+          fi
+          INSTR_COUNT=$(find .github/instructions -name "*.instructions.md" 2>/dev/null | wc -l)
+          echo "ℹ️  .github/instructions/: ${INSTR_COUNT} file(s)"
+          echo ""
+          echo "✅ Setup complete — Copilot cloud agent is ready to work"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/copilot-setup-steps.yml` to pre-install Node.js dependencies before each Copilot cloud agent session.

## Why this matters

Without this file, Copilot discovers and installs dependencies itself via trial and error — slow, non-deterministic, and impossible for repos with private packages. Pre-installing with `npm ci` ensures the agent always starts with exact, cached dependencies matching CI.

The verify step **fails the job if `AGENTS.md` is missing** — catching a misconfigured repo before the agent begins work.

## Stack

**Node.js 24 / npm** — TypeScript + Electron desktop app.

Steps:
1. `actions/checkout` (SHA-pinned)
2. `actions/setup-node@v4` with Node 24 + npm cache
3. `npm ci`
4. Verify environment (tool versions + AGENTS.md check)

## Standard

- Template source: [`petry-projects/.github/standards/workflows/copilot-setup-steps.yml`](https://github.com/petry-projects/.github/blob/main/standards/workflows/copilot-setup-steps.yml)
- Standard: [ci-standards.md §11 Copilot Cloud Agent Setup](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#11-copilot-cloud-agent-setup)
- Org standards PR: petry-projects/.github#328