### PR TITLE
ci(dev-lead): pin caller to @dev-lead/ring1 channel tag (ring membership #500)

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -43,7 +43,8 @@ permissions: {}
 
 jobs:
   dev-lead:
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@5a9a2476575cfcf0e730993f589587db054219f1 # main
+    # First-party channel tag — do NOT SHA-pin (AGENTS.md mutable-ref exception; rings #499/#500/#871).
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/ring1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
Completes the **ring1** membership for dev-lead per the canonical decision on petry-projects/.github-private#500 (`ring1` = TalkTerm + bmad-bgreat-suite).

Pins this caller to the **moving channel tag** `@dev-lead/ring1` — was SHA-pinned at `ded84ce4`, now restored to the channel tag — so it follows ring promotions/rollbacks via a central tag move (zero caller churn). Adds a guard comment: this first-party reusable ref must **not** be SHA-pinned (AGENTS.md mutable-ref exception).

⚠️ Carries `dev-lead:hands-off` to stop the agent re-converting `@dev-lead/ring1` → `@<sha>` during review (the bug tracked in petry-projects/.github-private#871). Once #871 lands, hands-off can be removed.

Refs petry-projects/.github-private#500, #871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)