### PR TITLE
chore: repin dev-lead stub to dev-lead/stable channel (#482)

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -48,7 +48,7 @@ jobs:
     # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
     # dev-lead's own scripts/prompts checkout. See ci-standards.md#dev-lead-agent.
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@3f9e5808b5f3965c96f5698b0d8ff46550b45ba7 # dev-lead/stable
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable
     with:
       agent_ref: dev-lead/stable
     secrets: inherit


### PR DESCRIPTION
Re-applies the channel repin from #318. dev-lead's SonarCloud auto-fix had reverted `dev-lead.yml` back to the frozen SHA there (a SHA satisfies S7637), so the stub merged still off-channel and the fleet dry-run still flags it. The S7637 rule exemption already landed with #318 (`sonar.issue.ignore.multicriteria.s7637_devlead`), so the `@dev-lead/stable` channel tag now passes SonarCloud and the pin holds — no auto-fix revert this time.

Refs #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)