### PR TITLE
chore: enroll TalkTerm in idea→initiative pipeline (ring1)

### DIFF
--- a/.github/workflows/idea-triage.yml
+++ b/.github/workflows/idea-triage.yml
@@ -1,0 +1,46 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/idea-triage.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/idea-triage-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All triage-dispatch logic lives in the
+#     reusable above.
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `idea-triage/stable` channel, a moving tag advanced centrally. Never
+#     repoint it to `@main`, a SHA, or a frozen `@vX`. Do not change the
+#     `secrets:` block.
+#   • You MAY change: the cron schedule if the weekly cadence doesn't suit.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo. A new release is rolled out by moving the channel tag
+#     centrally — never by editing callers.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Idea Triage — weekly ripeness shortlist, thin caller for the org-level reusable.
+#
+# Weekly, this re-dispatches the CENTRAL idea-triage (BMAD analyst) in
+# petry-projects/.github-private with this repo as the target. It scores this
+# repo's open Ideas Discussions (Ripe / Soon / Not yet) and refreshes this repo's
+# "Idea Promotion Queue" tracking issue (label `idea-triage`). It never applies
+# `idea:approved` — that stays the human's pick.
+#
+# To adopt:
+#   1. Copy this file to .github/workflows/idea-triage.yml in your repo.
+#   2. Ensure GitHub Discussions is enabled with an "Ideas" category.
+#   3. Confirm the org-level secret GH_PAT_WORKFLOWS is accessible.
+#   4. (Optional) Adjust the schedule cron.
+#
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+name: Idea Triage — Weekly Shortlist
+
+on:
+  schedule:
+    - cron: '30 13 * * 1' # Monday 13:30 UTC (just after the central dogfood run)
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  idea-triage:
+    uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    secrets: inherit

--- a/.github/workflows/idea-triage.yml
+++ b/.github/workflows/idea-triage.yml
@@ -42,6 +42,5 @@ permissions: {}
 
 jobs:
   idea-triage:
-    uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/ring1
-    secrets:
-      GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}
+    uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    secrets: inherit

--- a/.github/workflows/idea-triage.yml
+++ b/.github/workflows/idea-triage.yml
@@ -42,5 +42,6 @@ permissions: {}
 
 jobs:
   idea-triage:
-    uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/ring1
+    secrets:
+      GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}

--- a/.github/workflows/initiative-driver.yml
+++ b/.github/workflows/initiative-driver.yml
@@ -1,0 +1,89 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/initiative-driver.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Central driver:  petry-projects/.github-private/.github/workflows/initiative-driver.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All dependency-aware release logic (the
+#     `initiative:auto` gate, the DAG / `blocked_by` resolution, max-in-flight,
+#     and the dev-lead label hand-off) lives in the CENTRAL driver above. This
+#     stub only DISPATCHES that central workflow with this repo as target_repo.
+#   • Unlike the initiative-planner stub there is NO reusable: the central driver
+#     is pure-bash (no claude-code-action), so this stub dispatches the central
+#     workflow_dispatch DIRECTLY with `gh workflow run`. No LLM runs here.
+#   • You MUST NOT change: the dispatch target
+#     (-R petry-projects/.github-private -f target_repo=${{ github.repository }}),
+#     the `initiative:auto` label filter, or the PAT guard.
+#   • If you need different release behaviour, open a PR against the central
+#     driver in petry-projects/.github-private — never by editing callers.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Initiative Driver — per-repo dispatcher, thin caller for the central driver.
+#
+# On this repo's issues:[closed, labeled] (plus a safety-net off-peak schedule),
+# this stub dispatches the CENTRAL initiative-driver in
+# petry-projects/.github-private with target_repo=<this repo>. The central
+# driver then sweeps this repo's `initiative:auto` epics and releases their ready
+# sub-issues to dev-lead — so the central driver does not have to watch every
+# enrolled repo's events.
+#
+# To adopt:
+#   1. Copy this file verbatim to .github/workflows/initiative-driver.yml in your repo.
+#   2. Ensure the `initiative:auto` label exists on the repo.
+#   3. Confirm the org-level secret GH_PAT_WORKFLOWS is accessible **and its
+#      owner has write access to petry-projects/.github-private** (to dispatch
+#      the central workflow) **and to this repo** (the central driver applies the
+#      `dev-lead` label cross-repo with that PAT; a label applied with
+#      GITHUB_TOKEN would not trigger dev-lead).
+#
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+name: Initiative Driver — Dispatch Central
+
+on:
+  issues:
+    # closed:  a close may unblock successors — re-evaluate this repo's DAG.
+    # labeled: arming an epic with `initiative:auto` starts it immediately
+    #          (the job below filters to that label).
+    types: [closed, labeled]
+  schedule:
+    - cron: "41 3 * * *" # off-peak safety net for missed close events
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # One lane per repo so a close burst + the schedule does not fan out duplicate
+  # dispatches. cancel-in-progress=true cancels any pending/running redundant dispatches
+  # since the central driver sweeps all epics anyway.
+  group: initiative-driver-dispatch-${{ github.repository }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    # On a `labeled` event, only dispatch when the added label is the gate label
+    # (mirror the central driver) — otherwise every label change fans out a dispatch.
+    if: >-
+      github.event_name != 'issues' ||
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'initiative:auto'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Guard — PAT present
+        # PAT required: a workflow_dispatch fired with GITHUB_TOKEN never starts a run.
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::GH_PAT_WORKFLOWS is required — a workflow_dispatch fired with GITHUB_TOKEN never starts a run."
+            exit 1
+          fi
+
+      - name: Dispatch central initiative-driver
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+        run: |
+          gh workflow run initiative-driver.yml \
+            -R petry-projects/.github-private \
+            -f target_repo=${{ github.repository }}

--- a/.github/workflows/initiative-planner.yml
+++ b/.github/workflows/initiative-planner.yml
@@ -1,0 +1,48 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/initiative-planner.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/initiative-planner-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All idea→initiative dispatch logic (the
+#     `idea:approved` gate, the trusted-actor check, and the cross-repo dispatch
+#     to the central BMAD Scrum Master planner) lives in the reusable above.
+#   • You MUST NOT change: the `uses:` ref — it is pinned to the
+#     `initiative-planner/stable` channel, a moving tag advanced centrally.
+#     Never repoint it to `@main`, a SHA, or a frozen `@vX` (see
+#     ci-standards.md → Reusable workflow versioning). Also do not change the
+#     trigger events or the `secrets:` block.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo. A new release is rolled out by moving the channel tag
+#     centrally — never by editing callers, so no fanout PR is needed.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Initiative Planner — approval trigger, thin caller for the org-level reusable.
+#
+# When a maintainer adds `idea:approved` to an Ideas Discussion in this repo,
+# the reusable re-dispatches the CENTRAL initiative-planner (BMAD Scrum Master
+# "Bob") in petry-projects/.github-private with this repo as the target. Bob
+# reads this repo's Discussion and materializes an inert epic + sub-issue DAG
+# here (labelled `initiative`, NOT `initiative:auto`). A maintainer then adds
+# `initiative:auto` to the epic to hand it to initiative-driver. The frameworks
+# and planning logic stay vendored once, centrally.
+#
+# To adopt:
+#   1. Copy this file to .github/workflows/initiative-planner.yml in your repo.
+#   2. Ensure GitHub Discussions is enabled with an "Ideas" category.
+#   3. Ensure the `idea:approved` label exists on the repo.
+#   4. Confirm the org-level secret GH_PAT_WORKFLOWS is accessible.
+#
+# Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md
+name: Initiative Planner — Approval Trigger
+
+on:
+  discussion:
+    types: [labeled]
+
+permissions: {}
+
+jobs:
+  initiative-planner:
+    uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    secrets: inherit

--- a/.github/workflows/initiative-planner.yml
+++ b/.github/workflows/initiative-planner.yml
@@ -44,5 +44,6 @@ permissions: {}
 
 jobs:
   initiative-planner:
-    uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/ring1
+    secrets:
+      GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}

--- a/.github/workflows/initiative-planner.yml
+++ b/.github/workflows/initiative-planner.yml
@@ -44,6 +44,5 @@ permissions: {}
 
 jobs:
   initiative-planner:
-    uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/ring1
-    secrets:
-      GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}
+    uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    secrets: inherit

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**,docs/**
 # quiets the quality gate, not the code-scanning SARIF, so the
 # GitHub-Advanced-Security "SonarCloud" check still failed on new alerts (e.g.
 # the dev-lead repin). Third-party `uses:` keep full SHA-pin enforcement.
-sonar.issue.ignore.multicriteria=s7637_agentshield,s7637_prreview,s7637_prreviewmention,s7637_autorebase,s7637_dependabotrebase,s7637_dependabotautomerge,s7637_dependencyaudit,s7637_devlead,s7637_initiativeplanner,s7637_initiativetriage
+sonar.issue.ignore.multicriteria=s7637_agentshield,s7637_prreview,s7637_prreviewmention,s7637_autorebase,s7637_dependabotrebase,s7637_dependabotautomerge,s7637_dependencyaudit,s7637_devlead,s7637_initiativeplanner,s7637_initiativetriage,s7635_initiativeplanner,s7635_initiativetriage
 
 sonar.issue.ignore.multicriteria.s7637_agentshield.ruleKey=githubactions:S7637
 sonar.issue.ignore.multicriteria.s7637_agentshield.resourceKey=**/agent-shield.yml
@@ -44,3 +44,14 @@ sonar.issue.ignore.multicriteria.s7637_initiativeplanner.resourceKey=**/initiati
 
 sonar.issue.ignore.multicriteria.s7637_initiativetriage.ruleKey=githubactions:S7637
 sonar.issue.ignore.multicriteria.s7637_initiativetriage.resourceKey=**/idea-triage.yml
+
+# S7635 ("only pass required secrets") on the same first-party caller stubs:
+# the canonical templates use `secrets: inherit` so the central reusable
+# receives every secret it needs (PAT + Claude OAuth + more) — the reusable is
+# first-party and fully trusted, the same exemption rationale as S7637. Suppress
+# per stub file; stubs stay byte-for-byte verbatim (Fleet Monitor stub-drift).
+sonar.issue.ignore.multicriteria.s7635_initiativeplanner.ruleKey=githubactions:S7635
+sonar.issue.ignore.multicriteria.s7635_initiativeplanner.resourceKey=**/initiative-planner.yml
+
+sonar.issue.ignore.multicriteria.s7635_initiativetriage.ruleKey=githubactions:S7635
+sonar.issue.ignore.multicriteria.s7635_initiativetriage.resourceKey=**/idea-triage.yml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**,docs/**
 # quiets the quality gate, not the code-scanning SARIF, so the
 # GitHub-Advanced-Security "SonarCloud" check still failed on new alerts (e.g.
 # the dev-lead repin). Third-party `uses:` keep full SHA-pin enforcement.
-sonar.issue.ignore.multicriteria=s7637_agentshield,s7637_prreview,s7637_prreviewmention,s7637_autorebase,s7637_dependabotrebase,s7637_dependabotautomerge,s7637_dependencyaudit,s7637_devlead
+sonar.issue.ignore.multicriteria=s7637_agentshield,s7637_prreview,s7637_prreviewmention,s7637_autorebase,s7637_dependabotrebase,s7637_dependabotautomerge,s7637_dependencyaudit,s7637_devlead,s7637_initiativeplanner,s7637_initiativetriage
 
 sonar.issue.ignore.multicriteria.s7637_agentshield.ruleKey=githubactions:S7637
 sonar.issue.ignore.multicriteria.s7637_agentshield.resourceKey=**/agent-shield.yml
@@ -38,3 +38,9 @@ sonar.issue.ignore.multicriteria.s7637_dependencyaudit.resourceKey=**/dependency
 
 sonar.issue.ignore.multicriteria.s7637_devlead.ruleKey=githubactions:S7637
 sonar.issue.ignore.multicriteria.s7637_devlead.resourceKey=**/dev-lead.yml
+
+sonar.issue.ignore.multicriteria.s7637_initiativeplanner.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_initiativeplanner.resourceKey=**/initiative-planner.yml
+
+sonar.issue.ignore.multicriteria.s7637_initiativetriage.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_initiativetriage.resourceKey=**/idea-triage.yml


### PR DESCRIPTION
Enrolls **TalkTerm** (ring1 early-adopter) in the idea→initiative + initiative-driver pipeline, per ci-standards §10 and the staged ring rollout (petry-projects/.github#515). Tracked in petry-projects/.github-private#978.

## What this adds
TalkTerm already runs `feature-ideation`. This completes the loop:

| File | Pin | Trigger → action |
|---|---|---|
| `initiative-planner.yml` | `@initiative-planner/ring1` | `discussion[labeled idea:approved]` (trusted actor) → central planner builds an **inert** epic + story DAG here (`initiative`, not `initiative:auto`) |
| `idea-triage.yml` | `@idea-triage/ring1` | weekly + dispatch → refresh the Idea Promotion Queue |
| `initiative-driver.yml` | verbatim (direct `gh workflow run`) | `issues[closed,labeled initiative:auto]` + off-peak schedule → central driver releases ready sub-issues to dev-lead |

## Ring discipline (#515)
Consumer stubs pin the **`/ring1`** channel so a future staged version reaches TalkTerm at the ring1 stage. All ring channels currently coincide at `4d05546` (v1), so this is zero-behavior today. `initiative-driver.yml` and `feature-ideation.yml` carry no ring channel (driver dispatches directly; ideation is SHA-pinned `# v1`).

## Pre-reqs handled out-of-band
- Gate labels created on the repo: `idea:approved`, `initiative`, `initiative:auto`, `initiative:hold` (driver can't arm without `initiative:auto`).
- Discussions + "Ideas" category already enabled; `GH_PAT_WORKFLOWS` owner (donpetry-bot) has write access; `add-to-project` already wired.

## Validation after merge
`initiative-planner-canary` + Fleet Monitor stub-drift green; one clean `idea:approved` → inert epic; one armed epic → driver auto-releases a ready story to dev-lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)