### PR TITLE
chore: re-sync initiative stubs to S7635 inline marker (post .github#567)

### DIFF
--- a/.github/workflows/idea-triage.yml
+++ b/.github/workflows/idea-triage.yml
@@ -43,4 +43,4 @@ permissions: {}
 jobs:
   idea-triage:
     uses: petry-projects/.github/.github/workflows/idea-triage-reusable.yml@idea-triage/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/.github/workflows/initiative-planner.yml
+++ b/.github/workflows/initiative-planner.yml
@@ -45,4 +45,4 @@ permissions: {}
 jobs:
   initiative-planner:
     uses: petry-projects/.github/.github/workflows/initiative-planner-reusable.yml@initiative-planner/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable


### PR DESCRIPTION
Re-syncs the `initiative-planner.yml` and `idea-triage.yml` caller stubs to the updated canonical templates from petry-projects/.github#567 (merged), which moved SonarCloud **S7635** suppression to an inline `# NOSONAR(githubactions:S7635)` marker on the `secrets: inherit` line.

## Why
The ring1 enrollment merged on the *transitional* per-file S7635 multicriteria. Now that #567 added the inline marker to the templates, these stubs would show as **Fleet Monitor stub-drift** until they carry it too. This adds the marker so each stub is byte-exact to the template again (modulo the sanctioned `@…/ring1` channel ref).

## Change
- `secrets: inherit` → `secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable` on both stubs.
- Verified byte-identical to the merged template (ring1-adjusted).

The per-file S7635/S7637 multicriteria added at enrollment is now redundant (the inline markers cover both) but left in place for a minimal diff — belt-and-suspenders, matching the repo's other channel-pinned stubs.

Refs petry-projects/.github#567, petry-projects/.github-private#978, petry-projects/.github#515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)