### PR TITLE
ci(#614): repin feature-ideation onto ring channels

### DIFF
--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -140,7 +140,7 @@ jobs:
       discussions: write
       id-token: write
       actions: read
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@v2  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       # Populated by the `redispatch` bridge above (which forwards the new
       # Discussion number on `discussion: created`); empty on schedule/dispatch →


### PR DESCRIPTION
Completes the feature-ideation ring rollout (#614): channels ring0/ring1/stable were cut at v1.1.0 and it's registered in canary-rings.json (petry-projects/.github#661). Repin this consumer from its old ref onto the ring-appropriate feature-ideation channel.