### PR TITLE
ci(#651): repin add-to-project → @add-to-project/ring1

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -51,7 +51,7 @@ jobs:
   add-to-project:
     permissions:
       contents: read
-    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1


### PR DESCRIPTION
Completes the add-to-project ring rollout (#651): channels next/ring0/ring1 cut and it's registered as a managed ring agent (petry-projects/.github#667). Repin this consumer from @add-to-project/stable onto its ring channel.