### PR TITLE
ci: migrate pr-auto-review → @pr-auto-review/ring1 (canary)

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -51,6 +51,6 @@ jobs:
       checks: read
       actions: read
       statuses: read   # required by pr-auto-review-reusable.yml since #435
-    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@v2  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@pr-auto-review/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
       GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}


### PR DESCRIPTION
Migrate pr-auto-review off the frozen `@v2` tag onto its canary ring channel. pr-auto-review is now under the canary/ring model (petry-projects/.github#669): v1.0.0 was cut at @v2's exact commit, so this is a **zero-behavior-change** repin — same code, now staged/gated for future changes instead of big-bang @v2 moves.