### PR TITLE
chore: sync 8 org-standard workflow stub(s) from petry-projects/.github

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,9 +16,10 @@
 #   • If you need different behaviour, open a PR against the reusable.
 # ─────────────────────────────────────────────────────────────────────────────
 #
-# Auto-add this repo's qualifying issues, PRs, and Ideas-category discussions
-# to the org-level Initiatives project
-# (https://github.com/orgs/petry-projects/projects/1).
+# Track this repo's issues (all, un-gated) and dev-lead-labeled PRs on the
+# org-level Initiatives project
+# (https://github.com/orgs/petry-projects/projects/1). Ideas live in
+# Discussions and are not tracked here.
 #
 # To adopt: copy this file to .github/workflows/add-to-project.yml in your
 # repo. Requires the org secrets INITIATIVES_APP_ID and
@@ -26,7 +27,6 @@
 # app installation must include this repo. See petry-projects/.github#387.
 #
 # Tracking: petry-projects/.github#387, #415
-# Discussion: petry-projects/.github#386
 name: Auto-add to Initiatives project
 
 on:
@@ -34,16 +34,12 @@ on:
     types: [opened, labeled, unlabeled, reopened]
   pull_request_target:
     types: [opened, labeled, unlabeled, reopened, ready_for_review]
-  discussion:
-    types: [created, category_changed, deleted, transferred]
 
 permissions: {}
 
 concurrency:
   group: >-
-    add-to-project-${{ github.event_name == 'discussion'
-    && format('disc-{0}', github.event.discussion.number)
-    || format('{0}-{1}', github.event_name,
+    add-to-project-${{ format('{0}-{1}', github.event_name,
        github.event.issue.number || github.event.pull_request.number) }}
   cancel-in-progress: false
 
@@ -51,7 +47,7 @@ jobs:
   add-to-project:
     permissions:
       contents: read
-    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1

--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@agent-shield/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -50,4 +50,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    secrets: inherit

--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -51,4 +51,3 @@ jobs:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
     uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@auto-rebase/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -50,7 +50,7 @@ jobs:
     permissions:
       contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write  # re-approve PRs after branch update
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@dependabot-rebase/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,6 +1,6 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependency-audit.yml
-# Standard:        petry-projects/.github/standards/ci-standards.md#5-dependency-audit-dependency-auditym
+# Standard:        petry-projects/.github/standards/ci-standards.md#7-dependency-audit-dependency-audityml
 # Reusable:        petry-projects/.github/.github/workflows/dependency-audit-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@dependency-audit/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -8,9 +8,22 @@
 #   2. Ensure CLAUDE_CODE_OAUTH_TOKEN is set as an org or repo secret.
 #   3. Optionally set GH_PAT_WORKFLOWS (required if Claude pushes workflow files).
 #   4. Optionally set vars.DEV_LEAD_ENGINE = "claude" | "gemini" | "copilot".
+#   5. SonarCloud-gated repo? Nothing to do — the `uses:` line below already
+#      carries the inline `# NOSONAR(githubactions:S7637)` marker. The ref is a
+#      first-party reusable pinned to a moving channel/ring tag, so without the
+#      marker SonarCloud's githubactions:S7637 would fail the Quality Gate. The
+#      marker travels with this file on copy; no sonar-project.properties entry
+#      is needed. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637.
 #
-# UNLIKE claude.yml, this file has NO OIDC byte-for-byte constraint and may be
-# freely modified on PR branches to adjust triggers for repo-specific needs.
+# This stub is copied VERBATIM and is full-file identical across every adopting
+# repo, modulo the per-repo ring/channel pin on the `uses:` ref and its matching
+# `agent_ref` (below). Any other diff is drift, not a repo-specific liberty:
+# `on:`, `permissions:`, and `concurrency:` are NOT repo-adjustable — do not trim
+# a trigger, narrow a permission, or add a concurrency block on a PR branch. The
+# behavior lives in the reusable, so change it there (or via a standards PR) and
+# let the channel tag promote it centrally — never by editing this caller. See
+# https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#centralization-tiers and
+# https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#reusable-workflow-versioning--the-stable-channel.
 #
 # REQUIRED secrets: CLAUDE_CODE_OAUTH_TOKEN
 # OPTIONAL secrets: GH_PAT_WORKFLOWS, GOOGLE_API_KEY, GH_PAT
@@ -47,10 +60,10 @@ jobs:
     # change to dev-lead can no longer gate its own fix (the self-host circular
     # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
-    # dev-lead's own scripts/prompts checkout. See ci-standards.md#dev-lead-agent.
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    # dev-lead's own scripts/prompts checkout. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#dev-lead-agent.
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
-      agent_ref: dev-lead/stable
+      agent_ref: dev-lead/v1-ring1
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -37,5 +37,5 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/ring1  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets: inherit

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**,docs/**
 # quiets the quality gate, not the code-scanning SARIF, so the
 # GitHub-Advanced-Security "SonarCloud" check still failed on new alerts (e.g.
 # the dev-lead repin). Third-party `uses:` keep full SHA-pin enforcement.
-sonar.issue.ignore.multicriteria=s7637_agentshield,s7637_prreview,s7637_prreviewmention,s7637_autorebase,s7637_dependabotrebase,s7637_dependabotautomerge,s7637_dependencyaudit,s7637_devlead,s7637_initiativeplanner,s7637_initiativetriage,s7635_initiativeplanner,s7635_initiativetriage,s7637_addtoproject
+sonar.issue.ignore.multicriteria=s7637_agentshield,s7637_prreview,s7637_prreviewmention,s7637_autorebase,s7637_dependabotrebase,s7637_dependabotautomerge,s7637_dependencyaudit,s7637_devlead,s7637_initiativeplanner,s7637_initiativetriage,s7635_initiativeplanner,s7635_initiativetriage,s7637_addtoproject,s7635_autorebase
 
 sonar.issue.ignore.multicriteria.s7637_agentshield.ruleKey=githubactions:S7637
 sonar.issue.ignore.multicriteria.s7637_agentshield.resourceKey=**/agent-shield.yml
@@ -52,6 +52,9 @@ sonar.issue.ignore.multicriteria.s7637_initiativetriage.resourceKey=**/idea-tria
 # receives every secret it needs (PAT + Claude OAuth + more) — the reusable is
 # first-party and fully trusted, the same exemption rationale as S7637. Suppress
 # per stub file; stubs stay byte-for-byte verbatim (Fleet Monitor stub-drift).
+sonar.issue.ignore.multicriteria.s7635_autorebase.ruleKey=githubactions:S7635
+sonar.issue.ignore.multicriteria.s7635_autorebase.resourceKey=**/auto-rebase.yml
+
 sonar.issue.ignore.multicriteria.s7635_initiativeplanner.ruleKey=githubactions:S7635
 sonar.issue.ignore.multicriteria.s7635_initiativeplanner.resourceKey=**/initiative-planner.yml
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,10 +13,12 @@ sonar.exclusions=_bmad/**,_bmad-output/**,.claude/**,docs/**
 # quiets the quality gate, not the code-scanning SARIF, so the
 # GitHub-Advanced-Security "SonarCloud" check still failed on new alerts (e.g.
 # the dev-lead repin). Third-party `uses:` keep full SHA-pin enforcement.
-sonar.issue.ignore.multicriteria=s7637_agentshield,s7637_prreview,s7637_prreviewmention,s7637_autorebase,s7637_dependabotrebase,s7637_dependabotautomerge,s7637_dependencyaudit,s7637_devlead,s7637_initiativeplanner,s7637_initiativetriage,s7635_initiativeplanner,s7635_initiativetriage
+sonar.issue.ignore.multicriteria=s7637_agentshield,s7637_prreview,s7637_prreviewmention,s7637_autorebase,s7637_dependabotrebase,s7637_dependabotautomerge,s7637_dependencyaudit,s7637_devlead,s7637_initiativeplanner,s7637_initiativetriage,s7635_initiativeplanner,s7635_initiativetriage,s7637_addtoproject
 
 sonar.issue.ignore.multicriteria.s7637_agentshield.ruleKey=githubactions:S7637
 sonar.issue.ignore.multicriteria.s7637_agentshield.resourceKey=**/agent-shield.yml
+sonar.issue.ignore.multicriteria.s7637_addtoproject.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.s7637_addtoproject.resourceKey=**/add-to-project.yml
 
 sonar.issue.ignore.multicriteria.s7637_prreview.ruleKey=githubactions:S7637
 sonar.issue.ignore.multicriteria.s7637_prreview.resourceKey=**/pr-review.yml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -60,3 +60,4 @@ sonar.issue.ignore.multicriteria.s7635_initiativeplanner.resourceKey=**/initiati
 
 sonar.issue.ignore.multicriteria.s7635_initiativetriage.ruleKey=githubactions:S7635
 sonar.issue.ignore.multicriteria.s7635_initiativetriage.resourceKey=**/idea-triage.yml
+# add-to-project S7637 exemption added for #657 major-scoped-channel re-pin.


### PR DESCRIPTION
Syncs the following org-standard workflow stub(s) from `petry-projects/.github` (`standards/workflows/`), deployed verbatim:

- `pr-review-mention.yml`
- `dev-lead.yml`
- `agent-shield.yml`
- `auto-rebase.yml`
- `dependabot-automerge.yml`
- `dependabot-rebase.yml`
- `dependency-audit.yml`
- `add-to-project.yml`

Opened by `scripts/deploy-standard-workflows.sh`. Stubs are thin callers; all behaviour lives in the reusables. See `standards/ci-standards.md`. Labeled `standards-sync` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.