### PR TITLE
ci: inline NOSONAR(S7635) markers on secrets:inherit caller stubs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -36,4 +36,4 @@ jobs:
       contents: read
       pull-requests: read
     uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@dependabot-automerge/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -64,7 +64,7 @@ jobs:
     uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       agent_ref: dev-lead/v1-ring1
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -38,4 +38,4 @@ jobs:
     permissions:
       pull-requests: write
     uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@pr-review-mention/v2-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
-    secrets: inherit
+    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable


### PR DESCRIPTION
Closes #348

Appends the org-canonical inline `# NOSONAR(githubactions:S7635)` marker to every unmarked `secrets: inherit` line in this repo's first-party **caller-stub** workflows (thin callers that `uses:` a `petry-projects/...` reusable and forward org secrets via `secrets: inherit`).

Per the org standard, `secrets: inherit` to a trusted first-party reusable is the intended pattern here, so S7635 ("only pass required secrets") is a confirmed false positive on these stubs. The inline NOSONAR marker is the canonical, per-line suppression the org uses (matching the existing markers on `idea-triage.yml`/`initiative-planner.yml` where present).

No behavior change — marker-only edits; all workflow YAML validated. This drives the S7635 finding count to zero on the next audit run.