### PR TITLE
chore: insert org secrets baseline in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# >>> BEGIN petry-projects secrets baseline (managed by .github — do not edit) >>>
 # ============================================================================
 # petry-projects baseline .gitignore — SECRETS ONLY
 # ----------------------------------------------------------------------------
@@ -377,7 +378,7 @@ private.yml
 .earthly/config.yml
 
 # ---------------------------------------------------------------------------
-# 13. Agent / local worktrees (org coding policy)
+# 13. Agent / local worktrees and CI-generated tool artifacts (org coding policy)
 # ---------------------------------------------------------------------------
 # Temporary worktrees created by Claude Code and other agents. Not strictly
 # secret material, but the petry-projects coding guidelines require these
@@ -385,15 +386,22 @@ private.yml
 # be committed accidentally.
 .claude/worktrees/
 .worktrees/
+.dev-lead/
+# CI downloads actionlint into the repo root during linting; ignore the
+# generated binary so local lint runs cannot accidentally commit it.
+actionlint
+actionlint.tar.gz
 
 # ============================================================================
 # End of petry-projects secrets baseline
 # ============================================================================
+# <<< END petry-projects secrets baseline <<<
+#
+#
 
+# 13. Agent / local worktrees (org coding policy)
 
-# ============================================================================
 # TalkTerm — project-specific additions
-# ============================================================================
 
 # Node.js / npm
 node_modules/
@@ -426,9 +434,4 @@ stryker-tmp/
 .DS_Store
 Thumbs.db
 
-# ============================================================================
 # End of TalkTerm additions
-# ============================================================================
-.dev-lead/
-.dev-lead/
-.dev-lead/

--- a/.gitignore
+++ b/.gitignore
@@ -396,10 +396,6 @@ actionlint.tar.gz
 # End of petry-projects secrets baseline
 # ============================================================================
 # <<< END petry-projects secrets baseline <<<
-#
-#
-
-# 13. Agent / local worktrees (org coding policy)
 
 # TalkTerm — project-specific additions
 


### PR DESCRIPTION
Syncs the marker-wrapped org secrets baseline (L1) into \`.gitignore\` (INSERT), preserving this repo's per-repo L2 entries below the END marker. Opened by `scripts/sync-gitignore-baseline.sh` — see `standards/gitignore-standard.md`. Labeled `gitignore-baseline` and left for the normal review/auto-merge pipeline; the sweep never merges directly.