### PR TITLE
chore: sync 1 org-standard workflow stub(s) from petry-projects/.github

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -9,15 +9,11 @@
 #   3. Optionally set GH_PAT_WORKFLOWS (required if Claude pushes workflow files).
 #   4. Optionally set vars.DEV_LEAD_ENGINE = "claude" | "gemini" | "copilot".
 #   5. SonarCloud-gated repo? Nothing to do — the `uses:` line below already
-#      carries two inline NOSONAR markers that travel with this file on copy:
-#        • `# NOSONAR(githubactions:S7637)` on the `uses:` line — suppresses the
-#          "pin actions to a full SHA" rule (first-party channel ref; mutable tag
-#          is intentional — see ci-standards.md#reusable-workflow-versioning).
-#        • `# NOSONAR(githubactions:S7635)` on `secrets: inherit` — suppresses the
-#          "external reusable workflows should not inherit all secrets" rule (this
-#          is a trusted first-party private reusable, not a third-party workflow).
-#      No sonar-project.properties entry is needed. See
-#      https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637.
+#      carries the inline `# NOSONAR(githubactions:S7637)` marker. The ref is a
+#      first-party reusable pinned to a moving channel/ring tag, so without the
+#      marker SonarCloud's githubactions:S7637 would fail the Quality Gate. The
+#      marker travels with this file on copy; no sonar-project.properties entry
+#      is needed. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#sonarcloud-exemption-first-party-reusable-ref-s7637.
 #
 # This stub is copied VERBATIM and is full-file identical across every adopting
 # repo, modulo the per-repo ring/channel pin on the `uses:` ref and its matching
@@ -60,15 +56,15 @@ permissions: {}
 
 jobs:
   dev-lead:
-    # Pinned to the moving dev-lead/stable channel tag, not @main, so a broken
+    # Pinned to the moving dev-lead/v1-stable channel tag, not @main, so a broken
     # change to dev-lead can no longer gate its own fix (the self-host circular
-    # dependency). Promotion is done by moving the dev-lead/stable tag centrally; this
+    # dependency). Promotion is done by moving the dev-lead/v1-stable tag centrally; this
     # caller is never edited on release. agent_ref threads the same channel into
     # dev-lead's own scripts/prompts checkout. See https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#dev-lead-agent.
-    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/stable  # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@dev-lead/v1-ring1  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
-      agent_ref: dev-lead/stable
-    secrets: inherit  # NOSONAR(githubactions:S7635) first-party trusted reusable
+      agent_ref: dev-lead/v1-ring1
+    secrets: inherit
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## **User description**
Syncs the following org-standard workflow stub(s) from `petry-projects/.github` (`standards/workflows/`), deployed verbatim:

- `dev-lead.yml`

Opened by `scripts/deploy-standard-workflows.sh`. Stubs are thin callers; all behaviour lives in the reusables. See `standards/ci-standards.md`. Labeled `standards-sync` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.


___

## **CodeAnt-AI Description**
**Update the Dev-Lead workflow stub to use the v1 ring channel**

### What Changed
- The Dev-Lead workflow now points to the `v1-ring1` channel instead of the old stable channel
- The matching reference used by the workflow was updated so both values stay in sync
- The SonarCloud note was simplified to reflect the single required inline marker; the workflow still copies cleanly into adopting repos

### Impact
`✅ Consistent Dev-Lead workflow rollout`
`✅ Safer channel-based updates`
`✅ Fewer SonarCloud copy-time failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
