### PR TITLE
feat: implement issue #412 — Compliance: ci-concurrency-missing-sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,18 @@ on:
 
 permissions: {}
 
-# Serialize CI per Git ref so redundant runs don't pile up (Fleet Monitor #380).
-# When the same ref receives several pushes in quick succession (e.g. a bot adding
-# commits to a PR), outdated pull_request runs are cancelled since only the latest
-# commit matters. main-branch pushes are never cancelled so every merged commit is
-# verified. Mirrors the concurrency convention of every sibling workflow.
+# Scope the concurrency group to the commit SHA so every pushed commit gets its
+# own CI slot (Fleet Monitor #380; ci-standards.md#1-ci-pipeline-ciyml). A per-ref
+# group with cancel-in-progress can leave the HEAD commit with no results when
+# pushes arrive in quick succession — the final push may cancel the previous run
+# before GitHub fires a fresh pull_request:synchronize event. Including github.sha
+# gives each commit a distinct slot, so no commit is left unverified.
+# cancel-in-progress: true is retained to signal intent; it is effectively a no-op
+# under a SHA-scoped group but re-activates immediately if the formula ever reverts
+# to a per-ref pattern.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ci-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: true
 
 jobs:
   secret-scan:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,8 @@ permissions: {}
 # pushes arrive in quick succession — the final push may cancel the previous run
 # before GitHub fires a fresh pull_request:synchronize event. Including github.sha
 # gives each commit a distinct slot, so no commit is left unverified.
-# cancel-in-progress: true is retained to signal intent; it is effectively a no-op
-# under a SHA-scoped group but re-activates immediately if the formula ever reverts
-# to a per-ref pattern.
+# cancel-in-progress: true cancels duplicate runs for the same ref and SHA, but
+# cannot cancel runs for different commits because their groups are distinct.
 concurrency:
   group: ci-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true

--- a/scripts/test-ci-workflow.sh
+++ b/scripts/test-ci-workflow.sh
@@ -55,10 +55,10 @@ if [[ "$PASS" == "true" ]]; then
   fi
 fi
 
-# ── Check 4: cancel-in-progress is scoped to pull_request events ───────────
-# Outdated PR runs for a superseded commit are worthless and should be cancelled,
-# but every push to main must be verified and must never be cancelled. Encoding
-# this as `${{ github.event_name == 'pull_request' }}` satisfies both.
+# ── Check 4: cancel-in-progress is unconditionally true ───────────────────
+# With a SHA-scoped concurrency group each commit gets its own slot, so runs for
+# different commits never compete. cancel-in-progress: true only affects duplicate
+# runs within the same slot (same ref + SHA), making it safe to set unconditionally.
 if ! cancel=$(yq '.concurrency.cancel-in-progress' "$WORKFLOW" 2>/dev/null); then
   echo "FAIL: yq failed to parse $WORKFLOW. Please check if it is valid YAML."
   exit 1
@@ -66,12 +66,11 @@ fi
 if [[ "$cancel" == "null" || -z "$cancel" ]]; then
   echo "FAIL: 'concurrency.cancel-in-progress' is missing in $WORKFLOW"
   PASS=false
-elif [[ ! "$cancel" =~ pull_request ]]; then
-  echo "FAIL: 'concurrency.cancel-in-progress' (found: '$cancel') is not scoped to"
-  echo "      pull_request events in $WORKFLOW — main pushes must never be cancelled."
+elif [[ "$cancel" != "true" ]]; then
+  echo "FAIL: 'concurrency.cancel-in-progress' (found: '$cancel') must be 'true' in $WORKFLOW"
   PASS=false
 else
-  echo "PASS: 'concurrency.cancel-in-progress' scoped to pull_request events in $WORKFLOW"
+  echo "PASS: 'concurrency.cancel-in-progress' is unconditionally true in $WORKFLOW"
 fi
 
 echo ""


### PR DESCRIPTION
## **User description**
Closes #412

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
**Ensure every pushed commit gets its own CI result**

### What Changed
- CI now runs in a separate slot for each commit, so the latest push is not left without a check result
- Quick successive pushes no longer cancel the final commit before GitHub starts a fresh run
- The cancel-on-new-push behavior remains in place to avoid piling up outdated runs

### Impact
`✅ Fewer missing CI results on the latest commit`
`✅ More reliable pull request checks`
`✅ Fewer stalled reviews after rapid pushes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI run handling so each commit receives its own dedicated workflow slot.
  * Preserved automatic cancellation of redundant in-progress runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->