### PR TITLE
feat: implement issue #424 — Compliance: ruleset-drift-pr-quality-dismiss_stale_reviews_on_push

### DIFF
--- a/.github/workflows/apply-repo-settings.yml
+++ b/.github/workflows/apply-repo-settings.yml
@@ -7,7 +7,7 @@
 # compliance audits. Also triggerable manually for out-of-band remediation.
 # Reconciles: security_and_analysis settings (secret_scanning_ai_detection, etc.),
 # check-suite auto-trigger preferences, and the pr-quality ruleset's
-# allowed_merge_methods (squash-only).
+# allowed_merge_methods (squash-only) and dismiss_stale_reviews_on_push (true).
 #
 # Token: GH_PAT_WORKFLOWS (classic PAT with repo scope).
 # `administration` is not a valid GITHUB_TOKEN scope in Actions; and the

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -36,6 +36,11 @@ readonly -a CHECK_SUITE_APP_IDS=(1236702 347564) # Claude, CodeRabbit
 #           #pr-quality--standard-ruleset-all-repositories
 readonly PR_QUALITY_RULESET_NAME='pr-quality'
 readonly PR_QUALITY_MERGE_METHOD='squash'
+# The pr-quality ruleset requires stale approvals to be dismissed when new
+# commits are pushed, so a review always reflects the code being merged.
+# Standard: petry-projects/.github/standards/github-settings.md
+#           #pr-quality--standard-ruleset-all-repositories
+readonly PR_QUALITY_DISMISS_STALE_REVIEWS='true'
 readonly MISSING='missing'
 
 # resolve_repo <arg>
@@ -143,6 +148,25 @@ pr_quality_merge_methods_status() {
       end'
 }
 
+# pr_quality_dismiss_stale_reviews_status <ruleset_json>
+# Echoes the ruleset's pull_request-rule dismiss_stale_reviews_on_push value as
+# "true" or "false", or "missing" when the JSON is empty, has no pull_request
+# rule, or that rule omits the dismiss_stale_reviews_on_push parameter.
+pr_quality_dismiss_stale_reviews_status() {
+  local json="${1:-}"
+  if [[ -z "$json" ]]; then
+    printf '%s' "$MISSING"
+    return 0
+  fi
+  printf '%s' "$json" | jq -r --arg missing "$MISSING" '
+    (.rules // [])
+    | map(select(.type == "pull_request"))
+    | if length == 0 then $missing
+      else (.[0].parameters.dismiss_stale_reviews_on_push) as $d
+        | if $d == null then $missing else ($d | tostring) end
+      end'
+}
+
 # apply_pr_quality_merge_methods <owner/repo>
 # Reconciles the pr-quality ruleset's allowed_merge_methods to squash-only.
 # Skips when the ruleset is absent (org automation has not created it yet) or
@@ -201,6 +225,67 @@ apply_pr_quality_merge_methods() {
   gh api -X PUT "repos/${repo}/rulesets/${ruleset_id}" --input - <<<"$payload"
 }
 
+# apply_pr_quality_dismiss_stale_reviews <owner/repo>
+# Reconciles the pr-quality ruleset's dismiss_stale_reviews_on_push to true.
+# Skips when the ruleset is absent (org automation has not created it yet), when
+# it has no pull_request rule, or when already true. Otherwise PUTs the ruleset
+# back with the parameter forced to true, preserving all other fields (rules,
+# conditions, bypass actors, enforcement). Idempotent.
+apply_pr_quality_dismiss_stale_reviews() {
+  local repo="$1"
+  echo "Reconciling ${PR_QUALITY_RULESET_NAME} ruleset dismiss_stale_reviews_on_push for ${repo} ..."
+
+  local ruleset_id
+  if ! ruleset_id=$(gh api "repos/${repo}/rulesets" \
+    --jq "map(select(.name == \"${PR_QUALITY_RULESET_NAME}\")) | .[0].id // empty" 2>/dev/null); then
+    echo "  failed to query rulesets for ${repo}"
+    return 1
+  fi
+  if [[ -z "$ruleset_id" ]]; then
+    echo "  ${PR_QUALITY_RULESET_NAME} ruleset not found — org automation owns creation, skipping"
+    return 0
+  fi
+
+  local ruleset status
+  if ! ruleset=$(gh api "repos/${repo}/rulesets/${ruleset_id}" 2>/dev/null) || [[ -z "$ruleset" ]]; then
+    echo "  could not read ruleset ${ruleset_id} — skipping"
+    return 0
+  fi
+  if ! status=$(pr_quality_dismiss_stale_reviews_status "$ruleset"); then
+    echo "  failed to parse ruleset dismiss_stale_reviews_on_push status"
+    return 1
+  fi
+  if [[ "$status" == "$MISSING" ]]; then
+    echo "  no pull_request rule found — org automation owns creation, skipping"
+    return 0
+  fi
+  if [[ "$status" == "$PR_QUALITY_DISMISS_STALE_REVIEWS" ]]; then
+    echo "  already dismiss_stale_reviews_on_push=true — nothing to do"
+    return 0
+  fi
+  echo "  dismiss_stale_reviews_on_push '${status}' drifted — reconciling to true"
+
+  local payload
+  if ! payload=$(printf '%s' "$ruleset" | jq '
+    {
+      name: .name,
+      target: .target,
+      enforcement: .enforcement,
+      bypass_actors: (.bypass_actors // []),
+      conditions: .conditions,
+      rules: [
+        .rules[]
+        | if .type == "pull_request"
+          then .parameters.dismiss_stale_reviews_on_push = true
+          else . end
+      ]
+    }'); then
+    echo "  failed to generate payload for ruleset update"
+    return 1
+  fi
+  gh api -X PUT "repos/${repo}/rulesets/${ruleset_id}" --input - <<<"$payload"
+}
+
 # Run main only when executed directly, so tests can source the helpers.
 if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
   set -euo pipefail
@@ -211,5 +296,6 @@ if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
   apply_security_and_analysis "$repo"
   apply_check_suite_prefs "$repo"
   apply_pr_quality_merge_methods "$repo"
+  apply_pr_quality_dismiss_stale_reviews "$repo"
   echo "Done."
 fi

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -150,8 +150,9 @@ pr_quality_merge_methods_status() {
 
 # pr_quality_dismiss_stale_reviews_status <ruleset_json>
 # Echoes the ruleset's pull_request-rule dismiss_stale_reviews_on_push value as
-# "true" or "false", or "missing" when the JSON is empty, has no pull_request
-# rule, or that rule omits the dismiss_stale_reviews_on_push parameter.
+# "true" or "false", or "missing" when the JSON is empty or has no pull_request
+# rule. An absent parameter is treated as "false" (not "missing") so the apply
+# function can reconcile it to true.
 pr_quality_dismiss_stale_reviews_status() {
   local json="${1:-}"
   if [[ -z "$json" ]]; then
@@ -162,8 +163,7 @@ pr_quality_dismiss_stale_reviews_status() {
     (.rules // [])
     | map(select(.type == "pull_request"))
     | if length == 0 then $missing
-      else (.[0].parameters.dismiss_stale_reviews_on_push) as $d
-        | if $d == null then $missing else ($d | tostring) end
+      else (.[0].parameters.dismiss_stale_reviews_on_push // false | tostring)
       end'
 }
 

--- a/scripts/apply-repo-settings.test.sh
+++ b/scripts/apply-repo-settings.test.sh
@@ -71,6 +71,23 @@ assert_eq "pr_quality_merge_methods_status: rule without methods -> missing" \
 assert_eq "pr_quality_merge_methods_status: empty string -> missing" \
   "$MISSING" "$(pr_quality_merge_methods_status "")"
 
+# ── pr_quality_dismiss_stale_reviews_status ───────────────────────────────────
+ruleset_dismiss_true='{"rules":[{"type":"pull_request","parameters":{"dismiss_stale_reviews_on_push":true}}]}'
+ruleset_dismiss_false='{"rules":[{"type":"pull_request","parameters":{"dismiss_stale_reviews_on_push":false}}]}'
+ruleset_dismiss_no_pr='{"rules":[{"type":"required_status_checks","parameters":{}}]}'
+ruleset_dismiss_no_param='{"rules":[{"type":"pull_request","parameters":{}}]}'
+
+assert_eq "pr_quality_dismiss_stale_reviews_status: enabled -> true" \
+  "true" "$(pr_quality_dismiss_stale_reviews_status "$ruleset_dismiss_true")"
+assert_eq "pr_quality_dismiss_stale_reviews_status: disabled -> false" \
+  "false" "$(pr_quality_dismiss_stale_reviews_status "$ruleset_dismiss_false")"
+assert_eq "pr_quality_dismiss_stale_reviews_status: no pull_request rule -> missing" \
+  "$MISSING" "$(pr_quality_dismiss_stale_reviews_status "$ruleset_dismiss_no_pr")"
+assert_eq "pr_quality_dismiss_stale_reviews_status: rule without parameter -> missing" \
+  "$MISSING" "$(pr_quality_dismiss_stale_reviews_status "$ruleset_dismiss_no_param")"
+assert_eq "pr_quality_dismiss_stale_reviews_status: empty string -> missing" \
+  "$MISSING" "$(pr_quality_dismiss_stale_reviews_status "")"
+
 # ── resolve_repo ──────────────────────────────────────────────────────────────
 assert_eq "resolve_repo: bare name -> org/name" \
   "petry-projects/TalkTerm" "$(ORG=petry-projects resolve_repo "TalkTerm")"

--- a/scripts/apply-repo-settings.test.sh
+++ b/scripts/apply-repo-settings.test.sh
@@ -83,8 +83,8 @@ assert_eq "pr_quality_dismiss_stale_reviews_status: disabled -> false" \
   "false" "$(pr_quality_dismiss_stale_reviews_status "$ruleset_dismiss_false")"
 assert_eq "pr_quality_dismiss_stale_reviews_status: no pull_request rule -> missing" \
   "$MISSING" "$(pr_quality_dismiss_stale_reviews_status "$ruleset_dismiss_no_pr")"
-assert_eq "pr_quality_dismiss_stale_reviews_status: rule without parameter -> missing" \
-  "$MISSING" "$(pr_quality_dismiss_stale_reviews_status "$ruleset_dismiss_no_param")"
+assert_eq "pr_quality_dismiss_stale_reviews_status: rule without parameter -> false" \
+  "false" "$(pr_quality_dismiss_stale_reviews_status "$ruleset_dismiss_no_param")"
 assert_eq "pr_quality_dismiss_stale_reviews_status: empty string -> missing" \
   "$MISSING" "$(pr_quality_dismiss_stale_reviews_status "")"
 


### PR DESCRIPTION
## **User description**
Closes #424

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Repository Settings**
  * Pull-request reviews now dismiss stale approvals when new commits are pushed.
  * Existing merge-method and repository rule settings are preserved during updates.
  * Already-compliant settings remain unchanged.
* **Reliability**
  * Improved handling for missing, unreadable, incomplete, or empty configuration data.
* **Tests**
  * Added coverage for enabled, disabled, missing, incomplete, and empty configuration states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Enforce dismissal of stale pull request approvals after new commits

### What Changed
- The `pr-quality` ruleset now requires existing approvals to be dismissed when new commits are pushed.
- Scheduled, push-based, and manual settings checks detect disabled or missing enforcement and restore it while preserving the rest of the ruleset.
- Added coverage for enabled, disabled, missing, and incomplete ruleset configurations.

### Impact
`✅ Reviews always reflect the latest code`
`✅ Fewer merges based on outdated approvals`
`✅ Automatic correction of ruleset drift`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
