### PR TITLE
feat: implement issue #425 — Compliance: ruleset-drift-pr-quality-require_last_push_approval

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -39,7 +39,9 @@ repository:
 # The ruleset JSON's source of truth lives in petry-projects/.github
 # (standards/rulesets/pr-quality.json) and is applied org-wide by apply-rulesets.sh.
 # scripts/apply-repo-settings.sh additionally reconciles allowed_merge_methods to
-# [squash] on push to main + weekly, so drift is caught between compliance audits.
+# [squash] and require_last_push_approval to true on push to main + weekly, so
+# drift is caught between compliance audits (compliance:
+# ruleset-drift-pr-quality-require_last_push_approval).
 
 # --- Check suite auto-trigger ---
 # Standard: https://github.com/petry-projects/.github/blob/main/standards/github-settings.md

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -36,6 +36,12 @@ readonly -a CHECK_SUITE_APP_IDS=(1236702 347564) # Claude, CodeRabbit
 #           #pr-quality--standard-ruleset-all-repositories
 readonly PR_QUALITY_RULESET_NAME='pr-quality'
 readonly PR_QUALITY_MERGE_METHOD='squash'
+# The pr-quality ruleset requires that the most recent push be approved by a
+# reviewer other than its pusher. Expected true; GitHub omits/defaults it to
+# false, which is the drift this reconciler corrects.
+# Standard: petry-projects/.github/standards/github-settings.md
+#           #pr-quality--standard-ruleset-all-repositories
+readonly PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL='true'
 readonly MISSING='missing'
 
 # resolve_repo <arg>
@@ -143,6 +149,25 @@ pr_quality_merge_methods_status() {
       end'
 }
 
+# pr_quality_require_last_push_approval_status <ruleset_json>
+# Echoes the ruleset's pull_request-rule require_last_push_approval as "true" or
+# "false", or "missing" when the JSON is empty, has no pull_request rule, or that
+# rule omits the parameter (GitHub omits the key when the value is its default).
+pr_quality_require_last_push_approval_status() {
+  local json="${1:-}"
+  if [[ -z "$json" ]]; then
+    printf '%s' "$MISSING"
+    return 0
+  fi
+  printf '%s' "$json" | jq -r --arg missing "$MISSING" '
+    (.rules // [])
+    | map(select(.type == "pull_request"))
+    | if length == 0 then $missing
+      else (.[0].parameters.require_last_push_approval) as $v
+        | if $v == null then $missing else ($v | tostring) end
+      end'
+}
+
 # apply_pr_quality_merge_methods <owner/repo>
 # Reconciles the pr-quality ruleset's allowed_merge_methods to squash-only.
 # Skips when the ruleset is absent (org automation has not created it yet) or
@@ -201,6 +226,63 @@ apply_pr_quality_merge_methods() {
   gh api -X PUT "repos/${repo}/rulesets/${ruleset_id}" --input - <<<"$payload"
 }
 
+# apply_pr_quality_require_last_push_approval <owner/repo>
+# Reconciles the pr-quality ruleset's require_last_push_approval to true.
+# Skips when the ruleset is absent (org automation has not created it yet) or
+# already compliant. Otherwise PUTs the ruleset back with the parameter forced
+# to true, preserving all other fields (rules, conditions, bypass actors,
+# enforcement). Idempotent.
+apply_pr_quality_require_last_push_approval() {
+  local repo="$1"
+  echo "Reconciling ${PR_QUALITY_RULESET_NAME} ruleset require_last_push_approval for ${repo} ..."
+
+  local ruleset_id
+  if ! ruleset_id=$(gh api "repos/${repo}/rulesets" \
+    --jq "map(select(.name == \"${PR_QUALITY_RULESET_NAME}\")) | .[0].id // empty" 2>/dev/null); then
+    echo "  failed to query rulesets for ${repo}"
+    return 1
+  fi
+  if [[ -z "$ruleset_id" ]]; then
+    echo "  ${PR_QUALITY_RULESET_NAME} ruleset not found — org automation owns creation, skipping"
+    return 0
+  fi
+
+  local ruleset status
+  if ! ruleset=$(gh api "repos/${repo}/rulesets/${ruleset_id}" 2>/dev/null) || [[ -z "$ruleset" ]]; then
+    echo "  could not read ruleset ${ruleset_id} — skipping"
+    return 0
+  fi
+  if ! status=$(pr_quality_require_last_push_approval_status "$ruleset"); then
+    echo "  failed to parse ruleset require_last_push_approval status"
+    return 1
+  fi
+  if [[ "$status" == "$PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL" ]]; then
+    echo "  already require_last_push_approval=${PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL} — nothing to do"
+    return 0
+  fi
+  echo "  require_last_push_approval '${status}' drifted — reconciling to ${PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL}"
+
+  local payload
+  if ! payload=$(printf '%s' "$ruleset" | jq '
+    {
+      name: .name,
+      target: .target,
+      enforcement: .enforcement,
+      bypass_actors: (.bypass_actors // []),
+      conditions: .conditions,
+      rules: [
+        .rules[]
+        | if .type == "pull_request"
+          then .parameters.require_last_push_approval = true
+          else . end
+      ]
+    }'); then
+    echo "  failed to generate payload for ruleset update"
+    return 1
+  fi
+  gh api -X PUT "repos/${repo}/rulesets/${ruleset_id}" --input - <<<"$payload"
+}
+
 # Run main only when executed directly, so tests can source the helpers.
 if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
   set -euo pipefail
@@ -211,5 +293,6 @@ if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
   apply_security_and_analysis "$repo"
   apply_check_suite_prefs "$repo"
   apply_pr_quality_merge_methods "$repo"
+  apply_pr_quality_require_last_push_approval "$repo"
   echo "Done."
 fi

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -151,8 +151,9 @@ pr_quality_merge_methods_status() {
 
 # pr_quality_require_last_push_approval_status <ruleset_json>
 # Echoes the ruleset's pull_request-rule require_last_push_approval as "true" or
-# "false", or "missing" when the JSON is empty, has no pull_request rule, or that
-# rule omits the parameter (GitHub omits the key when the value is its default).
+# "false", or "missing" when the JSON is empty or has no pull_request rule.
+# When the pull_request rule exists but omits the parameter, returns "false"
+# (GitHub omits the key when the value is its default of false).
 pr_quality_require_last_push_approval_status() {
   local json="${1:-}"
   if [[ -z "$json" ]]; then
@@ -164,19 +165,20 @@ pr_quality_require_last_push_approval_status() {
     | map(select(.type == "pull_request"))
     | if length == 0 then $missing
       else (.[0].parameters.require_last_push_approval) as $v
-        | if $v == null then $missing else ($v | tostring) end
+        | if $v == null then "false" else ($v | tostring) end
       end'
 }
 
-# apply_pr_quality_merge_methods <owner/repo>
-# Reconciles the pr-quality ruleset's allowed_merge_methods to squash-only.
-# Skips when the ruleset is absent (org automation has not created it yet) or
-# already compliant. Otherwise PUTs the ruleset back with the merge methods
-# forced to [squash], preserving all other fields (rules, conditions, bypass
-# actors, enforcement). Idempotent.
-apply_pr_quality_merge_methods() {
+# apply_pr_quality_ruleset <owner/repo>
+# Reconciles both the allowed_merge_methods and require_last_push_approval
+# settings in the pr-quality ruleset in a single GET+PUT cycle, eliminating the
+# read-modify-write race that arises from two consecutive PUT operations sharing
+# stale state. Skips when the ruleset is absent. Skips require_last_push_approval
+# when the ruleset has no pull_request rule (org automation owns rule creation).
+# Idempotent.
+apply_pr_quality_ruleset() {
   local repo="$1"
-  echo "Reconciling ${PR_QUALITY_RULESET_NAME} ruleset merge methods for ${repo} ..."
+  echo "Reconciling ${PR_QUALITY_RULESET_NAME} ruleset for ${repo} ..."
 
   local ruleset_id
   if ! ruleset_id=$(gh api "repos/${repo}/rulesets" \
@@ -189,20 +191,41 @@ apply_pr_quality_merge_methods() {
     return 0
   fi
 
-  local ruleset status
+  local ruleset
   if ! ruleset=$(gh api "repos/${repo}/rulesets/${ruleset_id}" 2>/dev/null) || [[ -z "$ruleset" ]]; then
     echo "  could not read ruleset ${ruleset_id} — skipping"
     return 0
   fi
-  if ! status=$(pr_quality_merge_methods_status "$ruleset"); then
+
+  local merge_status rlpa_status needs_update=false
+  if ! merge_status=$(pr_quality_merge_methods_status "$ruleset"); then
     echo "  failed to parse ruleset merge methods status"
     return 1
   fi
-  if [[ "$status" == "$PR_QUALITY_MERGE_METHOD" ]]; then
-    echo "  already ${PR_QUALITY_MERGE_METHOD}-only — nothing to do"
+  if ! rlpa_status=$(pr_quality_require_last_push_approval_status "$ruleset"); then
+    echo "  failed to parse ruleset require_last_push_approval status"
+    return 1
+  fi
+
+  if [[ "$merge_status" == "$PR_QUALITY_MERGE_METHOD" ]]; then
+    echo "  already ${PR_QUALITY_MERGE_METHOD}-only — nothing to do for merge methods"
+  else
+    echo "  merge methods '${merge_status}' drifted — reconciling to ${PR_QUALITY_MERGE_METHOD}-only"
+    needs_update=true
+  fi
+
+  if [[ "$rlpa_status" == "$MISSING" ]]; then
+    echo "  no pull_request rule found — skipping require_last_push_approval reconciliation (org automation owns rule creation)"
+  elif [[ "$rlpa_status" == "$PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL" ]]; then
+    echo "  already require_last_push_approval=${PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL} — nothing to do"
+  else
+    echo "  require_last_push_approval '${rlpa_status}' drifted — reconciling to ${PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL}"
+    needs_update=true
+  fi
+
+  if [[ "$needs_update" == "false" ]]; then
     return 0
   fi
-  echo "  merge methods '${status}' drifted — reconciling to ${PR_QUALITY_MERGE_METHOD}-only"
 
   local payload
   if ! payload=$(printf '%s' "$ruleset" | jq \
@@ -214,66 +237,10 @@ apply_pr_quality_merge_methods() {
       bypass_actors: (.bypass_actors // []),
       conditions: .conditions,
       rules: [
-        .rules[]
+        (.rules // [])[]
         | if .type == "pull_request"
           then .parameters.allowed_merge_methods = [$method]
-          else . end
-      ]
-    }'); then
-    echo "  failed to generate payload for ruleset update"
-    return 1
-  fi
-  gh api -X PUT "repos/${repo}/rulesets/${ruleset_id}" --input - <<<"$payload"
-}
-
-# apply_pr_quality_require_last_push_approval <owner/repo>
-# Reconciles the pr-quality ruleset's require_last_push_approval to true.
-# Skips when the ruleset is absent (org automation has not created it yet) or
-# already compliant. Otherwise PUTs the ruleset back with the parameter forced
-# to true, preserving all other fields (rules, conditions, bypass actors,
-# enforcement). Idempotent.
-apply_pr_quality_require_last_push_approval() {
-  local repo="$1"
-  echo "Reconciling ${PR_QUALITY_RULESET_NAME} ruleset require_last_push_approval for ${repo} ..."
-
-  local ruleset_id
-  if ! ruleset_id=$(gh api "repos/${repo}/rulesets" \
-    --jq "map(select(.name == \"${PR_QUALITY_RULESET_NAME}\")) | .[0].id // empty" 2>/dev/null); then
-    echo "  failed to query rulesets for ${repo}"
-    return 1
-  fi
-  if [[ -z "$ruleset_id" ]]; then
-    echo "  ${PR_QUALITY_RULESET_NAME} ruleset not found — org automation owns creation, skipping"
-    return 0
-  fi
-
-  local ruleset status
-  if ! ruleset=$(gh api "repos/${repo}/rulesets/${ruleset_id}" 2>/dev/null) || [[ -z "$ruleset" ]]; then
-    echo "  could not read ruleset ${ruleset_id} — skipping"
-    return 0
-  fi
-  if ! status=$(pr_quality_require_last_push_approval_status "$ruleset"); then
-    echo "  failed to parse ruleset require_last_push_approval status"
-    return 1
-  fi
-  if [[ "$status" == "$PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL" ]]; then
-    echo "  already require_last_push_approval=${PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL} — nothing to do"
-    return 0
-  fi
-  echo "  require_last_push_approval '${status}' drifted — reconciling to ${PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL}"
-
-  local payload
-  if ! payload=$(printf '%s' "$ruleset" | jq '
-    {
-      name: .name,
-      target: .target,
-      enforcement: .enforcement,
-      bypass_actors: (.bypass_actors // []),
-      conditions: .conditions,
-      rules: [
-        .rules[]
-        | if .type == "pull_request"
-          then .parameters.require_last_push_approval = true
+            | .parameters = ((.parameters // {}) + {require_last_push_approval: true})
           else . end
       ]
     }'); then
@@ -292,7 +259,6 @@ if [[ "${BASH_SOURCE[0]:-$0}" == "$0" ]]; then
   }
   apply_security_and_analysis "$repo"
   apply_check_suite_prefs "$repo"
-  apply_pr_quality_merge_methods "$repo"
-  apply_pr_quality_require_last_push_approval "$repo"
+  apply_pr_quality_ruleset "$repo"
   echo "Done."
 fi

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -207,6 +207,11 @@ apply_pr_quality_ruleset() {
     return 1
   fi
 
+  if [[ "$rlpa_status" == "$MISSING" ]]; then
+    echo "  no pull_request rule found — skipping ruleset reconciliation (org automation owns rule creation)"
+    return 0
+  fi
+
   if [[ "$merge_status" == "$PR_QUALITY_MERGE_METHOD" ]]; then
     echo "  already ${PR_QUALITY_MERGE_METHOD}-only — nothing to do for merge methods"
   else
@@ -214,9 +219,7 @@ apply_pr_quality_ruleset() {
     needs_update=true
   fi
 
-  if [[ "$rlpa_status" == "$MISSING" ]]; then
-    echo "  no pull_request rule found — skipping require_last_push_approval reconciliation (org automation owns rule creation)"
-  elif [[ "$rlpa_status" == "$PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL" ]]; then
+  if [[ "$rlpa_status" == "$PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL" ]]; then
     echo "  already require_last_push_approval=${PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL} — nothing to do"
   else
     echo "  require_last_push_approval '${rlpa_status}' drifted — reconciling to ${PR_QUALITY_REQUIRE_LAST_PUSH_APPROVAL}"

--- a/scripts/apply-repo-settings.test.sh
+++ b/scripts/apply-repo-settings.test.sh
@@ -71,6 +71,23 @@ assert_eq "pr_quality_merge_methods_status: rule without methods -> missing" \
 assert_eq "pr_quality_merge_methods_status: empty string -> missing" \
   "$MISSING" "$(pr_quality_merge_methods_status "")"
 
+# ── pr_quality_require_last_push_approval_status ───────────────────────────────
+ruleset_rlpa_true='{"rules":[{"type":"pull_request","parameters":{"require_last_push_approval":true}}]}'
+ruleset_rlpa_false='{"rules":[{"type":"pull_request","parameters":{"require_last_push_approval":false}}]}'
+ruleset_rlpa_no_pr='{"rules":[{"type":"required_status_checks","parameters":{}}]}'
+ruleset_rlpa_absent='{"rules":[{"type":"pull_request","parameters":{}}]}'
+
+assert_eq "pr_quality_require_last_push_approval_status: true -> true" \
+  "true" "$(pr_quality_require_last_push_approval_status "$ruleset_rlpa_true")"
+assert_eq "pr_quality_require_last_push_approval_status: false (drifted) -> false" \
+  "false" "$(pr_quality_require_last_push_approval_status "$ruleset_rlpa_false")"
+assert_eq "pr_quality_require_last_push_approval_status: no pull_request rule -> missing" \
+  "$MISSING" "$(pr_quality_require_last_push_approval_status "$ruleset_rlpa_no_pr")"
+assert_eq "pr_quality_require_last_push_approval_status: rule without parameter -> missing" \
+  "$MISSING" "$(pr_quality_require_last_push_approval_status "$ruleset_rlpa_absent")"
+assert_eq "pr_quality_require_last_push_approval_status: empty string -> missing" \
+  "$MISSING" "$(pr_quality_require_last_push_approval_status "")"
+
 # ── resolve_repo ──────────────────────────────────────────────────────────────
 assert_eq "resolve_repo: bare name -> org/name" \
   "petry-projects/TalkTerm" "$(ORG=petry-projects resolve_repo "TalkTerm")"

--- a/scripts/apply-repo-settings.test.sh
+++ b/scripts/apply-repo-settings.test.sh
@@ -83,8 +83,8 @@ assert_eq "pr_quality_require_last_push_approval_status: false (drifted) -> fals
   "false" "$(pr_quality_require_last_push_approval_status "$ruleset_rlpa_false")"
 assert_eq "pr_quality_require_last_push_approval_status: no pull_request rule -> missing" \
   "$MISSING" "$(pr_quality_require_last_push_approval_status "$ruleset_rlpa_no_pr")"
-assert_eq "pr_quality_require_last_push_approval_status: rule without parameter -> missing" \
-  "$MISSING" "$(pr_quality_require_last_push_approval_status "$ruleset_rlpa_absent")"
+assert_eq "pr_quality_require_last_push_approval_status: rule without parameter -> false (GitHub default)" \
+  "false" "$(pr_quality_require_last_push_approval_status "$ruleset_rlpa_absent")"
 assert_eq "pr_quality_require_last_push_approval_status: empty string -> missing" \
   "$MISSING" "$(pr_quality_require_last_push_approval_status "")"
 


### PR DESCRIPTION
## **User description**
Closes #425

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
Enforce approval of the latest pull request push

### What Changed
- The `pr-quality` ruleset now requires the latest push to be approved by someone other than the person who pushed it.
- Repository settings automatically restore this approval requirement when it is missing or disabled, while preserving existing ruleset settings.
- Merge-method and latest-push approval corrections are applied together to avoid conflicting updates.
- Added coverage for enabled, disabled, missing, and default approval settings.

### Impact
`✅ Fewer unreviewed latest pushes merged`
`✅ Automatic correction of approval-setting drift`
`✅ Consistent squash-only pull request merges`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository quality settings now require approval from the latest push before changes can be merged.
  * Compliance checks now reconcile both squash-only merging and latest-push approval requirements for the main branch.

* **Bug Fixes**
  * Corrected settings reconciliation when approval requirements are missing, disabled, or inconsistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->